### PR TITLE
Fix #8 - Refactor project detection

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -17,7 +17,10 @@ type DeployCommand struct {
 }
 
 func (c *DeployCommand) Run(args []string) int {
-	c.Trellis.EnforceValid(c.UI)
+	if err := c.Trellis.LoadProject(); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
 
 	var environment string
 	var siteName string
@@ -78,6 +81,10 @@ Options:
 }
 
 func (c *DeployCommand) AutocompleteArgs() complete.Predictor {
+	if err := c.Trellis.LoadProject(); err != nil {
+		return complete.PredictNothing
+	}
+
 	return c.PredictSite()
 }
 

--- a/cmd/galaxy.go
+++ b/cmd/galaxy.go
@@ -13,7 +13,6 @@ type GalaxyCommand struct {
 }
 
 func (c *GalaxyCommand) Run(args []string) int {
-	c.Trellis.EnforceValid(c.UI)
 	c.UI.Output(c.Help())
 
 	return 0

--- a/cmd/galaxy_install.go
+++ b/cmd/galaxy_install.go
@@ -14,7 +14,10 @@ type GalaxyInstallCommand struct {
 }
 
 func (c *GalaxyInstallCommand) Run(args []string) int {
-	c.Trellis.EnforceValid(c.UI)
+	if err := c.Trellis.LoadProject(); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
 
 	galaxyInstall := exec.Command("ansible-galaxy", "install", "-r", "requirements.yml")
 	logCmd(galaxyInstall, true)

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -14,7 +14,10 @@ type InfoCommand struct {
 }
 
 func (c *InfoCommand) Run(args []string) int {
-	c.Trellis.EnforceValid(c.UI)
+	if err := c.Trellis.LoadProject(); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
 
 	for name, sites := range c.Trellis.Environments {
 		var siteNames []string

--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -34,7 +34,10 @@ func (c *ProvisionCommand) init() {
 }
 
 func (c *ProvisionCommand) Run(args []string) int {
-	c.Trellis.EnforceValid(c.UI)
+	if err := c.Trellis.LoadProject(); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
 
 	var environment string
 
@@ -123,6 +126,10 @@ Options:
 }
 
 func (c *ProvisionCommand) AutocompleteArgs() complete.Predictor {
+	if err := c.Trellis.LoadProject(); err != nil {
+		return complete.PredictNothing
+	}
+
 	return c.PredictEnvironment()
 }
 

--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -32,7 +32,10 @@ func (c *RollbackCommand) init() {
 }
 
 func (c *RollbackCommand) Run(args []string) int {
-	c.Trellis.EnforceValid(c.UI)
+	if err := c.Trellis.LoadProject(); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
 
 	var environment string
 	var siteName string
@@ -48,7 +51,7 @@ func (c *RollbackCommand) Run(args []string) int {
 		c.UI.Output(c.Help())
 		return 1
 	case 1:
-		c.UI.Error("Missing SITE argument\n")
+		c.UI.Error("Error: missing SITE argument\n")
 		c.UI.Output(c.Help())
 		return 1
 	case 2:
@@ -109,6 +112,10 @@ Options:
 }
 
 func (c *RollbackCommand) AutocompleteArgs() complete.Predictor {
+	if err := c.Trellis.LoadProject(); err != nil {
+		return complete.PredictNothing
+	}
+
 	return c.PredictSite()
 }
 

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ func main() {
 		},
 	}
 
-	trellis := trellis.Init()
+	trellis := trellis.NewTrellis()
 
 	c.Commands = map[string]cli.CommandFactory{
 		"deploy": func() (cli.Command, error) {


### PR DESCRIPTION
This refactors most of the detection and loading of a Trellis project.

The main bug in the original implementation was the use of `os.Chdir` as
the detect function traversed up the directory tree. When no project was
detected, the working directory was still changed to a root directory.
This likely wouldn't have the proper permissions, but even if it did,
the path the project was created at would be entirely wrong.

Now `os.Chdir` only happens when a valid Trellis project is actually
detected. This also only happens now for commands which need to act on a
project and call `LoadProject` explicitly.