### PR TITLE
Generate configs during project creation

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -19,11 +19,11 @@ func (c *InfoCommand) Run(args []string) int {
 		return 1
 	}
 
-	for name, sites := range c.Trellis.Environments {
+	for name, config := range c.Trellis.Environments {
 		var siteNames []string
 
-		for _, site := range sites {
-			siteNames = append(siteNames, site.Name)
+		for name, _ := range config.WordPressSites {
+			siteNames = append(siteNames, name)
 		}
 
 		c.UI.Info(fmt.Sprintf("%s => %s", name, strings.Join(siteNames, ", ")))

--- a/go.mod
+++ b/go.mod
@@ -14,5 +14,6 @@ require (
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	golang.org/x/arch v0.0.0-20181203225421-5a4828bb7045 // indirect
 	golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc // indirect
+	golang.org/x/net v0.0.0-20190119204137-ed066c81e75e
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ golang.org/x/arch v0.0.0-20181203225421-5a4828bb7045 h1:Pn8fQdvx+z1avAi7fdM2kRYW
 golang.org/x/arch v0.0.0-20181203225421-5a4828bb7045/go.mod h1:cYlCBUl1MsqxdiKgmc4uh7TxZfWSFLOGSRR090WDxt8=
 golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc h1:F5tKCVGp+MUAHhKp5MZtGqAlGX3+oCsiL1Q629FL90M=
 golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/net v0.0.0-20190119204137-ed066c81e75e h1:MDa3fSUp6MdYHouVmCCNz/zaH2a6CRcxY3VhT/K3C5Q=
+golang.org/x/net v0.0.0-20190119204137-ed066c81e75e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc h1:MeuS1UDyZyFH++6vVy44PuufTeFF0d0nfI6XB87YGSk=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func main() {
 			return &cmd.InfoCommand{UI: ui, Trellis: trellis}, nil
 		},
 		"new": func() (cli.Command, error) {
-			return cmd.NewNewCommand(ui), nil
+			return cmd.NewNewCommand(ui, trellis), nil
 		},
 		"provision": func() (cli.Command, error) {
 			return cmd.NewProvisionCommand(ui, trellis), nil

--- a/test-fixtures/trellis/group_vars/development/vault.yml
+++ b/test-fixtures/trellis/group_vars/development/vault.yml
@@ -1,0 +1,10 @@
+# Documentation: https://roots.io/trellis/docs/vault/
+vault_mysql_root_password: devpw
+
+# Variables to accompany `group_vars/development/wordpress_sites.yml`
+# Note: the site name (`example.com`) must match up with the site name in the above file.
+vault_wordpress_sites:
+  example.com:
+    admin_password: admin
+    env:
+      db_password: example_dbpassword

--- a/test-fixtures/trellis/group_vars/development/wordpress_sites.yml
+++ b/test-fixtures/trellis/group_vars/development/wordpress_sites.yml
@@ -1,0 +1,19 @@
+# Documentation: https://roots.io/trellis/docs/local-development-setup/
+# `wordpress_sites` options: https://roots.io/trellis/docs/wordpress-sites
+# Define accompanying passwords/secrets in group_vars/development/vault.yml
+
+wordpress_sites:
+  example.com:
+    site_hosts:
+      - canonical: example.test
+        redirects:
+          - www.example.test
+    local_path: ../site # path targeting local Bedrock site directory (relative to Ansible root)
+    admin_email: admin@example.test
+    multisite:
+      enabled: false
+    ssl:
+      enabled: false
+      provider: self-signed
+    cache:
+      enabled: false

--- a/test-fixtures/trellis/group_vars/production/vault.yml
+++ b/test-fixtures/trellis/group_vars/production/vault.yml
@@ -1,0 +1,24 @@
+# Documentation: https://roots.io/trellis/docs/vault/
+vault_mysql_root_password: productionpw
+
+# Documentation: https://roots.io/trellis/docs/security/
+vault_users:
+  - name: "{{ admin_user }}"
+    password: example_password
+    salt: "generateme"
+
+# Variables to accompany `group_vars/production/wordpress_sites.yml`
+# Note: the site name (`example.com`) must match up with the site name in the above file.
+vault_wordpress_sites:
+  example.com:
+    env:
+      db_password: example_dbpassword
+      # Generate your keys here: https://roots.io/salts.html
+      auth_key: "generateme"
+      secure_auth_key: "generateme"
+      logged_in_key: "generateme"
+      nonce_key: "generateme"
+      auth_salt: "generateme"
+      secure_auth_salt: "generateme"
+      logged_in_salt: "generateme"
+      nonce_salt: "generateme"

--- a/test-fixtures/trellis/group_vars/production/wordpress_sites.yml
+++ b/test-fixtures/trellis/group_vars/production/wordpress_sites.yml
@@ -1,0 +1,21 @@
+# Documentation: https://roots.io/trellis/docs/remote-server-setup/
+# `wordpress_sites` options: https://roots.io/trellis/docs/wordpress-sites
+# Define accompanying passwords/secrets in group_vars/production/vault.yml
+
+wordpress_sites:
+  example.com:
+    site_hosts:
+      - canonical: example.com
+        redirects:
+          - www.example.com
+    local_path: ../site # path targeting local Bedrock site directory (relative to Ansible root)
+    repo: git@github.com:example/example.com.git # replace with your Git repo URL
+    repo_subtree_path: site # relative path to your Bedrock/WP directory in your repo
+    branch: master
+    multisite:
+      enabled: false
+    ssl:
+      enabled: false
+      provider: letsencrypt
+    cache:
+      enabled: false

--- a/trellis/config.go
+++ b/trellis/config.go
@@ -1,0 +1,94 @@
+package trellis
+
+import (
+	"fmt"
+	suffix "golang.org/x/net/publicsuffix"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"log"
+	"strings"
+)
+
+const DefaultSiteName = "example.com"
+
+type Site struct {
+	SiteHosts       []SiteHost             `yaml:"site_hosts"`
+	LocalPath       string                 `yaml:"local_path"`
+	AdminEmail      string                 `yaml:"admin_email,omitempty"`
+	Branch          string                 `yaml:"branch,omitempty"`
+	Repo            string                 `yaml:"repo,omitempty"`
+	RepoSubtreePath string                 `yaml:"repo_subtree_path,omitempty"`
+	Multisite       map[string]interface{} `yaml:"multisite"`
+	Ssl             map[string]interface{} `yaml:"ssl"`
+	Cache           map[string]interface{} `yaml:"cache"`
+}
+
+type SiteHost struct {
+	Canonical string   `yaml:"canonical"`
+	Redirects []string `yaml:"redirects"`
+}
+
+type Config struct {
+	WordPressSites map[string]*Site `yaml:"wordpress_sites"`
+}
+
+func (t *Trellis) ParseConfig(path string) *Config {
+	configYaml, err := ioutil.ReadFile(path)
+
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	config := &Config{}
+
+	if err = yaml.Unmarshal(configYaml, &config); err != nil {
+		log.Fatalln(err)
+	}
+
+	return config
+}
+
+func (t *Trellis) GenerateSite(site *Site, name string, host string, env string) {
+	var redirect string
+
+	if env == "development" {
+		tld, _ := suffix.PublicSuffix(host)
+		host = strings.Replace(host, tld, "test", 1)
+
+		site.AdminEmail = fmt.Sprintf("admin@%s", host)
+		site.Branch = ""
+		site.Repo = ""
+		site.RepoSubtreePath = ""
+	} else {
+		site.AdminEmail = ""
+	}
+
+	if host[:4] == "www." {
+		redirect = strings.Replace(host, "www.", "", 1)
+	} else {
+		redirect = fmt.Sprintf("www.%s", host)
+	}
+
+	siteHost := SiteHost{
+		Canonical: host,
+		Redirects: []string{redirect},
+	}
+
+	site.SiteHosts = []SiteHost{siteHost}
+}
+
+func (t *Trellis) UpdateDefaultConfig(config *Config, name string, host string, env string) {
+	config.WordPressSites[name] = config.WordPressSites[DefaultSiteName]
+	delete(config.WordPressSites, DefaultSiteName)
+	t.GenerateSite(config.WordPressSites[name], name, host, env)
+}
+
+func (t *Trellis) WriteConfigYaml(config *Config, path string) error {
+	configYaml, err := yaml.Marshal(config)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return t.WriteYamlFile(path, configYaml)
+}

--- a/trellis/config_test.go
+++ b/trellis/config_test.go
@@ -1,0 +1,101 @@
+package trellis
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v2"
+	"strings"
+	"testing"
+)
+
+func TestUpdateDefaultConfig(t *testing.T) {
+	trellis := &Trellis{}
+
+	cases := []struct {
+		name         string
+		env          string
+		host         string
+		expectedYaml string
+	}{
+		{
+			"development_env",
+			"development",
+			"testsite.com",
+			`
+wordpress_sites:
+  testsite:
+    site_hosts:
+    - canonical: testsite.test
+      redirects:
+      - www.testsite.test
+    local_path: ../site
+    admin_email: admin@testsite.test
+    multisite:
+      enabled: false
+    ssl:
+      enabled: false
+      provider: self-signed
+    cache:
+      enabled: false
+`,
+		},
+		{
+			"development_env_www_host",
+			"development",
+			"www.testsite.com",
+			`
+wordpress_sites:
+  testsite:
+    site_hosts:
+    - canonical: www.testsite.test
+      redirects:
+      - testsite.test
+    local_path: ../site
+    admin_email: admin@www.testsite.test
+    multisite:
+      enabled: false
+    ssl:
+      enabled: false
+      provider: self-signed
+    cache:
+      enabled: false
+`,
+		},
+		{
+			"production_env",
+			"production",
+			"testsite.com",
+			`
+wordpress_sites:
+  testsite:
+    site_hosts:
+    - canonical: testsite.com
+      redirects:
+      - www.testsite.com
+    local_path: ../site
+    branch: master
+    repo: git@github.com:example/example.com.git
+    repo_subtree_path: site
+    multisite:
+      enabled: false
+    ssl:
+      enabled: false
+      provider: letsencrypt
+    cache:
+      enabled: false
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		config := trellis.ParseConfig(fmt.Sprintf("../test-fixtures/trellis/group_vars/%s/wordpress_sites.yml", tc.env))
+		trellis.UpdateDefaultConfig(config, "testsite", tc.host, tc.env)
+
+		configYaml, _ := yaml.Marshal(config)
+		expected := strings.TrimSpace(tc.expectedYaml)
+		output := strings.TrimSpace(string(configYaml))
+
+		if output != expected {
+			t.Errorf("expected yaml output %s but got %s", expected, output)
+		}
+	}
+}

--- a/trellis/vault.go
+++ b/trellis/vault.go
@@ -1,0 +1,128 @@
+package trellis
+
+import (
+	"crypto/rand"
+	"fmt"
+	"gopkg.in/yaml.v2"
+	"io"
+	"log"
+)
+
+type StringGenerator interface {
+	Generate() string
+}
+
+type RandomStringGenerator struct {
+	Length int
+}
+
+func (rs *RandomStringGenerator) Generate() string {
+	return generateRandomString(rs.Length)
+}
+
+type Vault struct {
+	MysqlRootPassword string                        `yaml:"vault_mysql_root_password"`
+	Users             []VaultUser                   `yaml:"vault_users,omitempty"`
+	WordPressSites    map[string]VaultWordPressSite `yaml:"vault_wordpress_sites"`
+}
+
+type VaultUser struct {
+	Name     string `yaml:"name"`
+	Password string `yaml:"password"`
+	Salt     string `yaml:"salt"`
+}
+
+type VaultWordPressSite struct {
+	AdminPassword string                `yaml:"admin_password"`
+	Env           VaultWordPressSiteEnv `yaml:"env"`
+}
+
+type VaultWordPressSiteEnv struct {
+	DbPassword     string `yaml:"db_password"`
+	AuthKey        string `yaml:"auth_key,omitempty"`
+	SecureAuthKey  string `yaml:"secure_auth_key,omitempty"`
+	LoggedInKey    string `yaml:"logged_in_key,omitempty"`
+	NonceKey       string `yaml:"nonce_key,omitempty"`
+	AuthSalt       string `yaml:"auth_salt,omitempty"`
+	SecureAuthSalt string `yaml:"secure_auth_salt,omitempty"`
+	LoggedInSalt   string `yaml:"logged_in_salt,omitempty"`
+	NonceSalt      string `yaml:"nonce_salt,omitempty"`
+}
+
+func (t *Trellis) GenerateVaultConfig(name string, env string, randomString StringGenerator) *Vault {
+	assertAvailablePRNG()
+	var siteEnv VaultWordPressSiteEnv
+
+	vault := Vault{MysqlRootPassword: randomString.Generate()}
+	siteEnv = VaultWordPressSiteEnv{
+		DbPassword:     randomString.Generate(),
+		AuthKey:        randomString.Generate(),
+		SecureAuthKey:  randomString.Generate(),
+		LoggedInKey:    randomString.Generate(),
+		NonceKey:       randomString.Generate(),
+		AuthSalt:       randomString.Generate(),
+		SecureAuthSalt: randomString.Generate(),
+		LoggedInSalt:   randomString.Generate(),
+		NonceSalt:      randomString.Generate(),
+	}
+
+	if env != "development" {
+		user := VaultUser{
+			Name:     "{{ admin_user }}",
+			Password: randomString.Generate(),
+			Salt:     randomString.Generate(),
+		}
+
+		vault.Users = []VaultUser{user}
+	}
+
+	vault.WordPressSites = make(map[string]VaultWordPressSite)
+	vault.WordPressSites[name] = VaultWordPressSite{
+		AdminPassword: randomString.Generate(),
+		Env:           siteEnv,
+	}
+
+	return &vault
+}
+
+func (t *Trellis) WriteVaultYaml(vault *Vault, path string) error {
+	vaultYaml, err := yaml.Marshal(vault)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return t.WriteYamlFile(path, vaultYaml)
+}
+
+func assertAvailablePRNG() {
+	buf := make([]byte, 1)
+
+	_, err := io.ReadFull(rand.Reader, buf)
+	if err != nil {
+		log.Fatal(fmt.Sprintf("Unable to generate random salt values. crypto/rand is unavailable: Read() failed with %#v", err))
+	}
+}
+
+func generateRandomBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+
+	_, err := rand.Read(b)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+func generateRandomString(n int) string {
+	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_[]{}<>~`+=,.;:/?|"
+
+	bytes, _ := generateRandomBytes(n)
+
+	for i, b := range bytes {
+		bytes[i] = letters[b%byte(len(letters))]
+	}
+
+	return string(bytes)
+}

--- a/trellis/vault_test.go
+++ b/trellis/vault_test.go
@@ -1,0 +1,84 @@
+package trellis
+
+import (
+	"gopkg.in/yaml.v2"
+	"strings"
+	"testing"
+)
+
+type MockStringGenerator struct{}
+
+func (ms *MockStringGenerator) Generate() string {
+	return "random"
+}
+
+func TestGenerateVaultConfig(t *testing.T) {
+	trellis := &Trellis{}
+	mockStringGenerator := &MockStringGenerator{}
+
+	cases := []struct {
+		name         string
+		siteName     string
+		env          string
+		expectedYaml string
+	}{
+		{
+			"development_env",
+			"testsite.com",
+			"development",
+			`
+vault_mysql_root_password: random
+vault_wordpress_sites:
+  testsite.com:
+    admin_password: random
+    env:
+      db_password: random
+      auth_key: random
+      secure_auth_key: random
+      logged_in_key: random
+      nonce_key: random
+      auth_salt: random
+      secure_auth_salt: random
+      logged_in_salt: random
+      nonce_salt: random
+`,
+		},
+		{
+			"production_env",
+			"testsite.com",
+			"production",
+			`
+vault_mysql_root_password: random
+vault_users:
+- name: '{{ admin_user }}'
+  password: random
+  salt: random
+vault_wordpress_sites:
+  testsite.com:
+    admin_password: random
+    env:
+      db_password: random
+      auth_key: random
+      secure_auth_key: random
+      logged_in_key: random
+      nonce_key: random
+      auth_salt: random
+      secure_auth_salt: random
+      logged_in_salt: random
+      nonce_salt: random
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		vault := trellis.GenerateVaultConfig(tc.siteName, tc.env, mockStringGenerator)
+
+		vaultYaml, _ := yaml.Marshal(vault)
+		expected := strings.TrimSpace(tc.expectedYaml)
+		output := strings.TrimSpace(string(vaultYaml))
+
+		if output != expected {
+			t.Errorf("expected yaml output %s but got %s", expected, output)
+		}
+	}
+}


### PR DESCRIPTION
`new` command will update default wordpress_sites and vault config files including generating all needed salts/passwords.