### PR TITLE
Improve new project prompts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module trellis-cli
 
 require (
 	github.com/dsnet/compress v0.0.0-20171208185109-cc9eb1d7ad76 // indirect
+	github.com/fatih/color v1.7.0
 	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
 	github.com/google/pprof v0.0.0-20190109223431-e84dfd68c163 // indirect
 	github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 // indirect

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ func main() {
 	c.Args = os.Args[1:]
 
 	ui := &cli.ColoredUi{
+		ErrorColor: cli.UiColorRed,
 		Ui: &cli.BasicUi{
 			Reader:      os.Stdin,
 			Writer:      os.Stdout,


### PR DESCRIPTION
`new` will not be a frequent command and this makes the CLI arguments more confusing.

Now it prompts for project name + site host. Colours have been added for better output as well.