### PR TITLE
Generate .vault_pass file

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -125,6 +125,16 @@ func (c *NewCommand) Run(args []string) int {
 		c.trellis.WriteVaultYaml(vault, filepath.Join("group_vars", env, "vault.yml"))
 	}
 
+	if err := c.trellis.GenerateVaultPassFile(".vault_pass"); err != nil {
+		c.UI.Error("Error writing .vault_pass file:")
+		c.UI.Error(err.Error())
+	}
+
+	if err := c.trellis.UpdateAnsibleConfig("defaults", "vault_password_file", ".vault_pass"); err != nil {
+		c.UI.Error("Error adding vault_password_file setting to ansible.cfg:")
+		c.UI.Error(err.Error())
+	}
+
 	fmt.Printf("\n%s project created with versions:\n", color.GreenString(name))
 	fmt.Printf("  Trellis v%s\n", trellisVersion)
 	fmt.Printf("  Bedrock v%s\n", bedrockVersion)

--- a/go.mod
+++ b/go.mod
@@ -16,5 +16,6 @@ require (
 	golang.org/x/arch v0.0.0-20181203225421-5a4828bb7045 // indirect
 	golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc // indirect
 	golang.org/x/net v0.0.0-20190119204137-ed066c81e75e
+	gopkg.in/ini.v1 v1.41.0
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -44,5 +44,7 @@ golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc h1:MeuS1UDyZyFH++6vVy44PuufT
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/ini.v1 v1.41.0 h1:Ka3ViY6gNYSKiVy71zXBEqKplnV35ImDLVG+8uoIklE=
+gopkg.in/ini.v1 v1.41.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -2,6 +2,7 @@ package trellis
 
 import (
 	"errors"
+	"gopkg.in/ini.v1"
 	"io/ioutil"
 	"log"
 	"os"
@@ -90,6 +91,22 @@ func (t *Trellis) SiteNamesFromEnvironment(environment string) []string {
 	sort.Strings(names)
 
 	return names
+}
+
+func (t *Trellis) UpdateAnsibleConfig(section string, key string, value string) error {
+	ansibleCfg := filepath.Join(t.Path, "ansible.cfg")
+	cfg, err := ini.Load(ansibleCfg)
+
+	if err != nil {
+		return err
+	}
+
+	cfg.Section(section).Key(key).SetValue(value)
+	if err := cfg.SaveTo(ansibleCfg); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (t *Trellis) WriteYamlFile(path string, data []byte) error {

--- a/trellis/vault.go
+++ b/trellis/vault.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"gopkg.in/yaml.v2"
 	"io"
+	"io/ioutil"
 	"log"
+	"path/filepath"
 )
 
 type StringGenerator interface {
@@ -83,6 +85,14 @@ func (t *Trellis) GenerateVaultConfig(name string, env string, randomString Stri
 	}
 
 	return &vault
+}
+
+func (t *Trellis) GenerateVaultPassFile(path string) error {
+	path = filepath.Join(t.Path, path)
+	randomString := RandomStringGenerator{Length: 64}
+
+	vaultPass := randomString.Generate()
+	return ioutil.WriteFile(path, []byte(vaultPass), 0600)
 }
 
 func (t *Trellis) WriteVaultYaml(vault *Vault, path string) error {


### PR DESCRIPTION
Also sets the `vault_password_file` in `ansible.cfg` by default.

This makes it way easier to get started with Vault but doesn't change anything by default. It's completely opt-in to actually encrypt the files.