### PR TITLE
Add Snapcraft support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,3 +43,14 @@ brew:
   test: |
     system "#{bin}/trellis --autocomplete-install"
     system "#{bin}/trellis -v"
+snapcraft:
+  name: trellis-cli
+  summary: A CLI to manage Trellis projects
+  description: |
+    Manage your Trellis projects without the need to memorise all the different Vagrant and Ansible commands.
+  replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64


### PR DESCRIPTION
This config change will allow building Snapcraft images (or snaps) for Linux distros that support it. Handy for Ubuntu 18.04 and its derivatives since it's bundled in the distro.

I'm not sure if we need to add anything to the Travis config for this, maybe someone else has input on that?

The author of GoReleaser has a blog post regarding this: https://carlosbecker.com/posts/goreleaser-snap-travis/