### PR TITLE
Add Yaml comment headers to configs

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	c := cli.NewCLI("trellis", "0.1.0")
+	c := cli.NewCLI("trellis", "0.2.1")
 	c.Args = os.Args[1:]
 
 	ui := &cli.ColoredUi{
@@ -38,7 +38,7 @@ func main() {
 			return &cmd.InfoCommand{UI: ui, Trellis: trellis}, nil
 		},
 		"new": func() (cli.Command, error) {
-			return cmd.NewNewCommand(ui, trellis), nil
+			return cmd.NewNewCommand(ui, trellis, c.Version), nil
 		},
 		"provision": func() (cli.Command, error) {
 			return cmd.NewProvisionCommand(ui, trellis), nil

--- a/trellis/config.go
+++ b/trellis/config.go
@@ -82,13 +82,3 @@ func (t *Trellis) UpdateDefaultConfig(config *Config, name string, host string, 
 	delete(config.WordPressSites, DefaultSiteName)
 	t.GenerateSite(config.WordPressSites[name], name, host, env)
 }
-
-func (t *Trellis) WriteConfigYaml(config *Config, path string) error {
-	configYaml, err := yaml.Marshal(config)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	return t.WriteYamlFile(path, configYaml)
-}

--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -3,6 +3,7 @@ package trellis
 import (
 	"errors"
 	"gopkg.in/ini.v1"
+	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"log"
 	"os"
@@ -109,8 +110,14 @@ func (t *Trellis) UpdateAnsibleConfig(section string, key string, value string) 
 	return nil
 }
 
-func (t *Trellis) WriteYamlFile(path string, data []byte) error {
+func (t *Trellis) WriteYamlFile(s interface{}, path string, header string) error {
+	data, err := yaml.Marshal(s)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	path = filepath.Join(t.Path, path)
+	data = append([]byte(header), data...)
 
 	if err := ioutil.WriteFile(path, data, 0666); err != nil {
 		log.Fatal(err)

--- a/trellis/vault.go
+++ b/trellis/vault.go
@@ -3,7 +3,6 @@ package trellis
 import (
 	"crypto/rand"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"log"
@@ -96,16 +95,6 @@ func (t *Trellis) GenerateVaultPassFile(path string) error {
 
 	vaultPass := randomString.Generate()
 	return ioutil.WriteFile(path, []byte(vaultPass), 0600)
-}
-
-func (t *Trellis) WriteVaultYaml(vault *Vault, path string) error {
-	vaultYaml, err := yaml.Marshal(vault)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	return t.WriteYamlFile(path, vaultYaml)
 }
 
 func assertAvailablePRNG() {


### PR DESCRIPTION
Example:

```
Created by trellis-cli v0.2.1
Documentation: https://roots.io/trellis/docs/wordpress-sites/
```

trellis-cli was stripping the default comments in `vault.yml` and
`wordpress_sites.yml`. While this doesn't restore the default ones, it
provides a docs URL and lets the user know that it was created by
trellis-cli and the version.