### PR TITLE
Fix #32 - Remove special chars from random strings

### DIFF
--- a/trellis/vault.go
+++ b/trellis/vault.go
@@ -118,7 +118,7 @@ func generateRandomBytes(n int) ([]byte, error) {
 }
 
 func generateRandomString(n int) string {
-	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_[]{}<>~`+=,.;:/?|"
+	const letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 	bytes, _ := generateRandomBytes(n)
 


### PR DESCRIPTION
Special characters can cause issues in a few places:

* YAML files/templates
* Certain commands/software such as Ansible's `mysql_db`

While it may seem less secure to generate passwords without these
characters (ie: easier to brute-force), password length is still the most
important factor. Special characters are often used to ensure *human*
created passwords have more entropy (less random); however, these
strings are cryptographically randomly generated so they don't suffer
from these human issues.

So this should cause less isuess while still being secure enough for our
use cases.

Caveat: I don't really know anything about cryptography.