### PR TITLE
Deploy: only require SITE if there's more than one

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -29,9 +29,7 @@ func (c *DeployCommand) Run(args []string) int {
 		c.UI.Output(c.Help())
 		return 1
 	case 1:
-		c.UI.Error("Error: missing SITE argument\n")
-		c.UI.Output(c.Help())
-		return 1
+		environment = args[0]
 	case 2:
 		environment = args[0]
 		siteName = args[1]
@@ -39,6 +37,24 @@ func (c *DeployCommand) Run(args []string) int {
 		c.UI.Error(fmt.Sprintf("Error: too many arguments (expected 2, got %d)\n", len(args)))
 		c.UI.Output(c.Help())
 		return 1
+	}
+
+	_, ok := c.Trellis.Environments[environment]
+	if !ok {
+		c.UI.Error(fmt.Sprintf("Error: %s is not a valid environment", environment))
+		return 1
+	}
+
+	if siteName == "" {
+		sites := c.Trellis.SiteNamesFromEnvironment(environment)
+
+		if len(sites) > 1 {
+			c.UI.Error("Error: missing SITE argument\n")
+			c.UI.Output(c.Help())
+			return 1
+		}
+
+		siteName = sites[0]
 	}
 
 	deploy := execCommand("./bin/deploy.sh", environment, siteName)

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -34,10 +34,17 @@ func TestDeployRunValidations(t *testing.T) {
 			1,
 		},
 		{
-			"missing_site_arg",
+			"invalid_env",
 			true,
-			[]string{"development"},
-			"Error: missing SITE argument",
+			[]string{"foo"},
+			"Error: foo is not a valid environment",
+			1,
+		},
+		{
+			"invalid_env_with_site",
+			true,
+			[]string{"foo", "example.com"},
+			"Error: foo is not a valid environment",
 			1,
 		},
 		{
@@ -69,9 +76,10 @@ func TestDeployRunValidations(t *testing.T) {
 }
 
 func TestDeployRun(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
 	ui := cli.NewMockUi()
-	mockProject := &MockProject{true}
-	trellis := trellis.NewTrellis(mockProject)
+	project := &trellis.Project{}
+	trellis := trellis.NewTrellis(project)
 	deployCommand := &DeployCommand{ui, trellis}
 
 	execCommand = mockExecCommand
@@ -86,6 +94,12 @@ func TestDeployRun(t *testing.T) {
 		{
 			"default",
 			[]string{"development", "example.com"},
+			"./bin/deploy.sh development example.com",
+			0,
+		},
+		{
+			"site_not_needed_in_defaut_case",
+			[]string{"development"},
 			"./bin/deploy.sh development example.com",
 			0,
 		},

--- a/trellis/testing.go
+++ b/trellis/testing.go
@@ -4,10 +4,11 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 )
 
-func loadFixtureProject(t *testing.T) func() {
+func LoadFixtureProject(t *testing.T) func() {
 	old, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -18,14 +19,15 @@ func loadFixtureProject(t *testing.T) func() {
 		t.Fatalf("err: %s", err)
 	}
 
-	cmd := exec.Command("cp", "-a", "testdata/trellis/", tempDir)
+	os.Chdir("../trellis")
+	cmd := exec.Command("cp", "-a", "testdata/trellis", tempDir)
 	err = cmd.Run()
 
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
-	os.Chdir(tempDir)
+	os.Chdir(filepath.Join(tempDir, "trellis"))
 
 	return func() {
 		if err := os.Chdir(old); err != nil {


### PR DESCRIPTION
Fixes #29 

If a Trellis project only has one site for an environment, the `SITE` argument can be left off.