### PR TITLE
Improve vault encrypt/decrypt commands

### DIFF
--- a/cmd/vault.go
+++ b/cmd/vault.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"bufio"
+	"os"
 	"strings"
 
 	"github.com/mitchellh/cli"
@@ -26,4 +28,27 @@ Usage: trellis vault <subcommand> [<args>]
 `
 
 	return strings.TrimSpace(helpText)
+}
+
+func isFileEncrypted(filepath string) (isEncrypted bool, err error) {
+	file, err := os.Open(filepath)
+	if err != nil {
+		return false, err
+	}
+
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Scan()
+	line := scanner.Text()
+
+	if strings.HasPrefix(line, "$ANSIBLE_VAULT") {
+		return true, nil
+	}
+
+	if err := scanner.Err(); err != nil {
+		return false, err
+	}
+
+	return false, nil
 }

--- a/cmd/vault_decrypt.go
+++ b/cmd/vault_decrypt.go
@@ -66,6 +66,26 @@ func (c *VaultDecryptCommand) Run(args []string) int {
 		files = strings.Split(c.files, ",")
 	}
 
+	var filesToDecrypt []string
+
+	for _, file := range files {
+		isEncrypted, err := isFileEncrypted(file)
+
+		if err != nil {
+			c.UI.Error(err.Error())
+			return 1
+		}
+
+		if isEncrypted {
+			filesToDecrypt = append(filesToDecrypt, file)
+		}
+	}
+
+	if len(filesToDecrypt) == 0 {
+		c.UI.Info(color.GreenString("All files already decrypted"))
+		return 0
+	}
+
 	vaultArgs = append(vaultArgs, files...)
 
 	vaultDecrypt := execCommand("ansible-vault", vaultArgs...)

--- a/cmd/vault_encrypt.go
+++ b/cmd/vault_encrypt.go
@@ -66,7 +66,27 @@ func (c *VaultEncryptCommand) Run(args []string) int {
 		files = strings.Split(c.files, ",")
 	}
 
-	vaultArgs = append(vaultArgs, files...)
+	var filesToEncrypt []string
+
+	for _, file := range files {
+		isEncrypted, err := isFileEncrypted(file)
+
+		if err != nil {
+			c.UI.Error(err.Error())
+			return 1
+		}
+
+		if !isEncrypted {
+			filesToEncrypt = append(filesToEncrypt, file)
+		}
+	}
+
+	if len(filesToEncrypt) == 0 {
+		c.UI.Info(color.GreenString("All files already encrypted"))
+		return 0
+	}
+
+	vaultArgs = append(vaultArgs, filesToEncrypt...)
 
 	vaultEncrypt := execCommand("ansible-vault", vaultArgs...)
 	logCmd(vaultEncrypt, c.UI, true)

--- a/trellis/complete_test.go
+++ b/trellis/complete_test.go
@@ -1,30 +1,17 @@
 package trellis
 
 import (
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/posener/complete"
 )
 
-func testChdir(t *testing.T, dir string) func() {
-	t.Helper()
-	old, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	return func() { os.Chdir(old) }
-}
-
 func TestPredictEnvironment(t *testing.T) {
 	project := &Project{}
 	trellis := NewTrellis(project)
 
-	defer testChdir(t, "testdata/trellis")()
+	defer TestChdir(t, "testdata/trellis")()
 
 	if err := trellis.LoadProject(); err != nil {
 		t.Fatalf(err.Error())
@@ -70,7 +57,7 @@ func TestPredictSite(t *testing.T) {
 	project := &Project{}
 	trellis := NewTrellis(project)
 
-	defer testChdir(t, "testdata/trellis")()
+	defer TestChdir(t, "testdata/trellis")()
 
 	if err := trellis.LoadProject(); err != nil {
 		t.Fatalf(err.Error())

--- a/trellis/testdata/trellis/group_vars/all/vault.yml
+++ b/trellis/testdata/trellis/group_vars/all/vault.yml
@@ -1,0 +1,10 @@
+# Documentation: https://roots.io/trellis/docs/vault/
+vault_mysql_root_password: devpw
+
+# Variables to accompany `group_vars/development/wordpress_sites.yml`
+# Note: the site name (`example.com`) must match up with the site name in the above file.
+vault_wordpress_sites:
+  example.com:
+    admin_password: admin
+    env:
+      db_password: example_dbpassword

--- a/trellis/testdata/trellis/group_vars/production/encrypted.yml
+++ b/trellis/testdata/trellis/group_vars/production/encrypted.yml
@@ -1,0 +1,2 @@
+$ANSIBLE_VAULT;1.1;AES256
+encrypted

--- a/trellis/testing.go
+++ b/trellis/testing.go
@@ -37,3 +37,15 @@ func LoadFixtureProject(t *testing.T) func() {
 		os.RemoveAll(tempDir)
 	}
 }
+
+func TestChdir(t *testing.T, dir string) func() {
+	t.Helper()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	return func() { os.Chdir(old) }
+}


### PR DESCRIPTION
Fixes #42

This makes both `vault encrypt` and `vault decrypt` idempotent and more user friendly.

`ansible-vault` returns errors if you try to encrypt already encrypted files (or decrypt already decrypted files) which is annoying. Now these cases will be handled without errors by testing ahead of time the state of files.