### PR TITLE
Improves site usage for deploy and rollback

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -55,6 +55,13 @@ func (c *DeployCommand) Run(args []string) int {
 		}
 
 		siteName = sites[0]
+	} else {
+		site := c.Trellis.SiteFromEnvironmentAndName(environment, siteName)
+
+		if site == nil {
+			c.UI.Error(fmt.Sprintf("Error: %s is not a valid site", siteName))
+			return 1
+		}
 	}
 
 	deploy := execCommand("./bin/deploy.sh", environment, siteName)

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestDeployRunValidations(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
 	ui := cli.NewMockUi()
 
 	cases := []struct {
@@ -45,6 +46,13 @@ func TestDeployRunValidations(t *testing.T) {
 			true,
 			[]string{"foo", "example.com"},
 			"Error: foo is not a valid environment",
+			1,
+		},
+		{
+			"invalid_site",
+			true,
+			[]string{"development", "nosite"},
+			"Error: nosite is not a valid site",
 			1,
 		},
 		{

--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -50,9 +50,7 @@ func (c *RollbackCommand) Run(args []string) int {
 		c.UI.Output(c.Help())
 		return 1
 	case 1:
-		c.UI.Error("Error: missing SITE argument\n")
-		c.UI.Output(c.Help())
-		return 1
+		environment = args[0]
 	case 2:
 		environment = args[0]
 		siteName = args[1]
@@ -60,6 +58,31 @@ func (c *RollbackCommand) Run(args []string) int {
 		c.UI.Error(fmt.Sprintf("Error: too many arguments (expected 2, got %d)\n", len(args)))
 		c.UI.Output(c.Help())
 		return 1
+	}
+
+	_, ok := c.Trellis.Environments[environment]
+	if !ok {
+		c.UI.Error(fmt.Sprintf("Error: %s is not a valid environment", environment))
+		return 1
+	}
+
+	if siteName == "" {
+		sites := c.Trellis.SiteNamesFromEnvironment(environment)
+
+		if len(sites) > 1 {
+			c.UI.Error("Error: missing SITE argument\n")
+			c.UI.Output(c.Help())
+			return 1
+		}
+
+		siteName = sites[0]
+	} else {
+		site := c.Trellis.SiteFromEnvironmentAndName(environment, siteName)
+
+		if site == nil {
+			c.UI.Error(fmt.Sprintf("Error: %s is not a valid site", siteName))
+			return 1
+		}
 	}
 
 	extraVars := fmt.Sprintf("env=%s site=%s", environment, siteName)


### PR DESCRIPTION
`deploy` supported using the first site as a default while `rollback`
did not. This adds support for that to `rollback` for consistency. Both
also have validation for the SITE argument now.

Tests have also been improved and made consistent.