### PR TITLE
Add `alias` command

### DIFF
--- a/cmd/alias.go
+++ b/cmd/alias.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"github.com/fatih/color"
+	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	. "trellis-cli/templates"
+	"trellis-cli/trellis"
+)
+
+type AliasCommand struct {
+	UI      cli.Ui
+	flags   *flag.FlagSet
+	Trellis *trellis.Trellis
+	local   string
+}
+
+func NewAliasCommand(ui cli.Ui, trellis *trellis.Trellis) *AliasCommand {
+	c := &AliasCommand{UI: ui, Trellis: trellis}
+	c.init()
+	return c
+}
+
+func (c *AliasCommand) init() {
+	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+	c.flags.Usage = func() { c.UI.Info(c.Help()) }
+	c.flags.StringVar(&c.local, "local", "development", "local environment name, default: development")
+}
+
+func (c *AliasCommand) Run(args []string) int {
+	if err := c.Trellis.LoadProject(); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	if err := c.flags.Parse(args); err != nil {
+		return 1
+	}
+
+	args = c.flags.Args()
+
+	switch len(args) {
+	case 0:
+	default:
+		c.UI.Error(fmt.Sprintf("Error: too many arguments (expected 0, got %d)\n", len(args)))
+		c.UI.Output(c.Help())
+		return 1
+	}
+
+	// Template playbook files to Trellis
+	files := map[string]string{
+		"alias.yml":      ALIAS_YML,
+		"alias.yml.j2":   ALIAS_YML_J2,
+		"alias-copy.yml": ALIAS_COPY_YML,
+	}
+	for filename, fileContent := range files {
+		writeFile(filename, TrimSpace(fileContent))
+		defer deleteFile(filename)
+	}
+
+	environments := c.Trellis.EnvironmentNames()
+	var remoteEnvironments []string
+	for _, environment := range environments {
+		if environment != c.local {
+			remoteEnvironments = append(remoteEnvironments, environment)
+		}
+	}
+
+	tempDir, tempDirErr := ioutil.TempDir("", "trellis-alias-")
+	if tempDirErr != nil {
+		log.Fatal(tempDirErr)
+	}
+	defer os.RemoveAll(tempDir)
+
+	for _, environment := range remoteEnvironments {
+		alias := execCommand("ansible-playbook", "alias.yml", "-vvv", "-e", "env="+environment, "-e", "trellis_alias_j2=alias.yml.j2", "-e", "trellis_alias_temp_dir="+tempDir)
+		appendEnvironmentVariable(alias, "ANSIBLE_RETRY_FILES_ENABLED=false")
+
+		logCmd(alias, c.UI, true)
+		err := alias.Run()
+
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Error running ansible-playbook alias.yml: %s", err))
+			return 1
+		}
+	}
+
+	combined := ""
+	for _, environment := range remoteEnvironments {
+		part, err := ioutil.ReadFile(filepath.Join(tempDir, environment+".yml.part"))
+		if err != nil {
+			log.Fatal(err)
+		}
+		combined = combined + string(part)
+	}
+
+	combinedYmlPath := filepath.Join(tempDir, "/combined.yml")
+	writeFileErr := ioutil.WriteFile(combinedYmlPath, []byte(combined), 0644)
+	if writeFileErr != nil {
+		log.Fatal(writeFileErr)
+	}
+
+	aliasCopy := execCommand("ansible-playbook", "alias-copy.yml", "-e", "env="+c.local, "-e", "trellis_alias_combined="+combinedYmlPath)
+	appendEnvironmentVariable(aliasCopy, "ANSIBLE_RETRY_FILES_ENABLED=false")
+
+	logCmd(aliasCopy, c.UI, true)
+	aliasCopyErr := aliasCopy.Run()
+
+	if aliasCopyErr != nil {
+		c.UI.Error(fmt.Sprintf("Error running ansible-playbook alias-copy.yml: %s", aliasCopyErr))
+		return 1
+	}
+
+	c.UI.Info(color.GreenString("✓ wp-cli.trellis-alias.yml generated"))
+	message := `
+Action Required: Add these lines into wp-cli.yml or wp-cli.local.yml
+
+_: 
+  inherit: wp-cli.trellis-alias.yml
+`
+	c.UI.Info(strings.TrimSpace(message))
+
+	return 0
+}
+
+func (c *AliasCommand) Synopsis() string {
+	return "Generate WP CLI aliases for remote environments"
+}
+
+func (c *AliasCommand) Help() string {
+	helpText := `
+Usage: trellis alias [options]
+
+Generate WP CLI aliases for remote environments
+
+Options:
+      --local (default: development) Local environment name
+  -h, --help  show this help
+`
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *AliasCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"--local": complete.PredictNothing,
+	}
+}

--- a/cmd/alias_test.go
+++ b/cmd/alias_test.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/cli"
+	"trellis-cli/trellis"
+)
+
+func TestAliasArgumentValidations(t *testing.T) {
+	ui := cli.NewMockUi()
+
+	cases := []struct {
+		name            string
+		projectDetected bool
+		args            []string
+		out             string
+		code            int
+	}{
+		{
+			"no_project",
+			false,
+			nil,
+			"No Trellis project detected",
+			1,
+		},
+		{
+			"too_many_args",
+			true,
+			[]string{"foo"},
+			"Error: too many arguments",
+			1,
+		},
+	}
+
+	for _, tc := range cases {
+		mockProject := &MockProject{tc.projectDetected}
+		trellis := trellis.NewTrellis(mockProject)
+
+		aliasCommand := NewAliasCommand(ui, trellis)
+
+		code := aliasCommand.Run(tc.args)
+
+		if code != tc.code {
+			t.Errorf("%s: expected code %d to be %d", tc.name, code, tc.code)
+		}
+
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+
+		if !strings.Contains(combined, tc.out) {
+			t.Errorf("expected output %q to contain %q", combined, tc.out)
+		}
+	}
+}
+
+func TestIntegrationAlias(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	bin := os.Getenv("TEST_BINARY")
+	if bin == "" {
+		t.Error("TEST_BINARY not supplied")
+	}
+	if _, err := os.Stat(bin); os.IsNotExist(err) {
+		t.Error(bin + "not exist")
+	}
+
+	dummy := os.Getenv("TEST_DUMMY")
+	if dummy == "" {
+		t.Error("TEST_DUMMY not supplied")
+	}
+
+	actualPath := path.Join(dummy, "site/wp-cli.trellis-alias.yml")
+
+	os.Remove(actualPath)
+	defer os.Remove(actualPath)
+
+	alias := exec.Command(bin, "alias")
+	alias.Dir = path.Join(dummy, "trellis")
+
+	alias.Run()
+
+	if _, err := os.Stat(actualPath); os.IsNotExist(err) {
+		t.Error("wp-cli.trellis-alias.yml file not generated")
+	}
+
+	actualByte, _ := ioutil.ReadFile(actualPath)
+	actual := string(actualByte)
+
+	expectedByte, _ := ioutil.ReadFile("./testdata/expected/alias/wp-cli.trellis-alias.yml")
+	expected := string(expectedByte)
+
+	if actual != expected {
+		t.Errorf("expected .wp-cli.trellis-alias.yml file \n%s to be \n%s", actual, expected)
+	}
+}

--- a/cmd/dot_env.go
+++ b/cmd/dot_env.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/mitchellh/cli"
@@ -14,15 +12,6 @@ import (
 type DotEnvCommand struct {
 	UI      cli.Ui
 	Trellis *trellis.Trellis
-}
-
-func appendEnvironmentVariable(cmd *exec.Cmd, elem string) {
-	env := os.Environ()
-	// To allow mockExecCommand injects its environment variables
-	if cmd.Env != nil {
-		env = cmd.Env
-	}
-	cmd.Env = append(env, elem)
 }
 
 func (c *DotEnvCommand) Run(args []string) int {

--- a/cmd/environment_variable.go
+++ b/cmd/environment_variable.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+)
+
+func appendEnvironmentVariable(cmd *exec.Cmd, elem string) {
+	env := os.Environ()
+	// To allow mockExecCommand injects its environment variables
+	if cmd.Env != nil {
+		env = cmd.Env
+	}
+	cmd.Env = append(env, elem)
+}

--- a/cmd/testdata/expected/alias/wp-cli.trellis-alias.yml
+++ b/cmd/testdata/expected/alias/wp-cli.trellis-alias.yml
@@ -1,0 +1,6 @@
+@production:
+  ssh: "web@your_server_hostname:22"
+  path: "/srv/www/example.com/current/web/wp"
+@staging:
+  ssh: "web@your_server_hostname:22"
+  path: "/srv/www/example.com/current/web/wp"

--- a/main.go
+++ b/main.go
@@ -26,6 +26,9 @@ func main() {
 	trellis := trellis.NewTrellis(project)
 
 	c.Commands = map[string]cli.CommandFactory{
+		"alias": func() (cli.Command, error) {
+			return cmd.NewAliasCommand(ui, trellis), nil
+		},
 		"check": func() (cli.Command, error) {
 			return &cmd.CheckCommand{UI: ui, Trellis: trellis}, nil
 		},

--- a/templates/alias_copy_yml.go
+++ b/templates/alias_copy_yml.go
@@ -1,0 +1,17 @@
+package templates
+
+const ALIAS_COPY_YML = `
+---
+- hosts: web:&{{ env }}
+  connection: local
+  gather_facts: false
+  tasks:
+    - copy:
+        src: "{{ trellis_alias_combined }}"
+        dest: "{{ item.value.local_path }}/wp-cli.trellis-alias.yml"
+        mode: '0644'
+        force: yes
+        decrypt: no
+      with_dict: "{{ wordpress_sites }}"
+      run_once: true
+`

--- a/templates/alias_yml.go
+++ b/templates/alias_yml.go
@@ -1,0 +1,21 @@
+package templates
+
+const ALIAS_YML = `
+---
+- hosts: web:&{{ env }}
+  connection: local
+  gather_facts: false
+  tasks:
+    - file:
+        path: "{{ trellis_alias_temp_dir }}"
+        state: directory
+        mode: '0755'
+      with_dict: "{{ wordpress_sites }}"
+      run_once: true
+    - template:
+        src: "{{ trellis_alias_j2 }}"
+        dest: "{{ trellis_alias_temp_dir }}/{{ env }}.yml.part"
+        mode: '0644'
+      with_dict: "{{ wordpress_sites }}"
+      run_once: true
+`

--- a/templates/alias_yml_j2.go
+++ b/templates/alias_yml_j2.go
@@ -1,0 +1,7 @@
+package templates
+
+const ALIAS_YML_J2 = `
+@{{ env }}:
+  ssh: "{{ web_user }}@{{ ansible_host }}:{{ ansible_port | default('22') }}"
+  path: "{{ project_root | default(www_root + '/' + item.key) | regex_replace('^~\/','') }}/{{ item.current_path | default('current') }}/web/wp"
+`


### PR DESCRIPTION
Generate WP CLI aliases for remote environments. See: https://github.com/ItinerisLtd/cognomen/issues/3#issuecomment-456563138

Ported from https://github.com/ItinerisLtd/cognomen/tree/88f77e416da8cb6bdb48deee430b9ccf4a7a486e