### PR TITLE
Virtualenv support

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -2,18 +2,72 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/mitchellh/cli"
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
+
+	"github.com/mitchellh/cli"
+	"trellis-cli/trellis"
 )
 
-func logCmd(cmd *exec.Cmd, ui cli.Ui, output bool) {
-	cmd.Stderr = os.Stderr
+type ExecCommand struct {
+	UI      cli.Ui
+	Trellis *trellis.Trellis
+}
 
-	if output {
-		cmd.Stdout = &cli.UiWriter{ui}
+func (c *ExecCommand) Run(args []string) int {
+	if err := c.Trellis.LoadProject(); err != nil {
+		c.UI.Error(err.Error())
+		return 1
 	}
 
-	fmt.Println("Running command =>", strings.Join(cmd.Args, " "))
+	var command string
+	var cmdArgs []string
+
+	switch len(args) {
+	case 0:
+		c.UI.Error("Error: missing COMMAND argument\n")
+		c.UI.Output(c.Help())
+		return 1
+	default:
+		command = args[0]
+		cmdArgs = args
+	}
+
+	cmdPath, err := exec.LookPath(command)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error: %s not found", command))
+		return 1
+	}
+
+	env := os.Environ()
+	execErr := syscall.Exec(cmdPath, cmdArgs, env)
+	if execErr != nil {
+		c.UI.Error(fmt.Sprintf("Error running %s: %s", args[0], execErr))
+		return 1
+	}
+
+	return 0
+}
+
+func (c *ExecCommand) Synopsis() string {
+	return "Exec runs a command in the Trellis virtualenv"
+}
+
+func (c *ExecCommand) Help() string {
+	helpText := `
+Usage: trellis exec [options]
+
+Exec activates the Trellis virtual environment and executes the command specified.
+
+Run a custom ansible-playbook command:
+
+  $ trellis exec ansible-playbook --version
+
+Options:
+  -h, --help show this help
+`
+
+	return strings.TrimSpace(helpText)
 }

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/cli"
+	"trellis-cli/trellis"
+)
+
+func TestExecRunValidations(t *testing.T) {
+	ui := cli.NewMockUi()
+
+	cases := []struct {
+		name            string
+		projectDetected bool
+		args            []string
+		out             string
+		code            int
+	}{
+		{
+			"no_project",
+			false,
+			nil,
+			"No Trellis project detected",
+			1,
+		},
+	}
+
+	for _, tc := range cases {
+		mockProject := &MockProject{tc.projectDetected}
+		trellis := trellis.NewTrellis(mockProject)
+		execCommand := &ExecCommand{ui, trellis}
+
+		code := execCommand.Run(tc.args)
+
+		if code != tc.code {
+			t.Errorf("expected code %d to be %d", code, tc.code)
+		}
+
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+
+		if !strings.Contains(combined, tc.out) {
+			t.Errorf("expected output %q to contain %q", combined, tc.out)
+		}
+	}
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -60,7 +60,7 @@ func (c *InitCommand) Run(args []string) int {
 
 	if err != nil {
 		s.Stop()
-		c.UI.Error(fmt.Sprintf("Error installing pip requirements", err))
+		c.UI.Error(fmt.Sprintf("Error installing pip requirements: %s", err))
 		return 1
 	}
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -29,6 +29,16 @@ func (c *InitCommand) Run(args []string) int {
 		return 1
 	}
 
+	if ok, _ := c.Trellis.Virtualenv.Installed(); !ok {
+		c.UI.Info("virtualenv not found")
+		s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+		s.Suffix = " Installing virtualenv..."
+		s.FinalMSG = "✓ virtualenv installed\n"
+		s.Start()
+		c.Trellis.Virtualenv.Install()
+		s.Stop()
+	}
+
 	c.UI.Info(fmt.Sprintf("Creating virtualenv in %s", c.Trellis.Virtualenv.Path))
 
 	err := c.Trellis.Virtualenv.Create()
@@ -70,8 +80,18 @@ Usage: trellis init [options]
 Initializes an existing Trellis project to be managed by trellis-cli.
 The initialization process does two things:
 
-1. creates a virtual environment via virtualenv to manage dependencies
-2. installs dependencies via pip (specified by requirements.txt in your Trellis project)
+1. installs virtualenv if necessary (see below for details)
+2. creates a virtual environment specific to the project to manage dependencies
+3. installs dependencies via pip (specified by requirements.txt in your Trellis project)
+
+trellis-cli will attempt to use an already installed method to manage virtualenvs
+and only fallback to installing virtualenv if necessary:
+
+1. if python3 is installed, use built-in virtualenv feature
+2. use virtualenv command if available
+3. finally install virtualenv at $HOME/.trellis/virtualenv
+
+To learn more about virtual environments, see https://docs.python.org/3/tutorial/venv.html
 
 This command is idempotent meaning it can be run multiple times without side-effects.
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -29,6 +29,11 @@ func (c *InitCommand) Run(args []string) int {
 		return 1
 	}
 
+	if err := c.Trellis.CreateConfigDir(); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
 	if ok, _ := c.Trellis.Virtualenv.Installed(); !ok {
 		c.UI.Info("virtualenv not found")
 		s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/mitchellh/cli"
+	"trellis-cli/trellis"
+)
+
+type InitCommand struct {
+	UI      cli.Ui
+	Trellis *trellis.Trellis
+}
+
+func (c *InitCommand) Run(args []string) int {
+	if err := c.Trellis.LoadProject(); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	switch len(args) {
+	case 0:
+	default:
+		c.UI.Error(fmt.Sprintf("Error: too many arguments (expected 0, got %d)\n", len(args)))
+		c.UI.Output(c.Help())
+		return 1
+	}
+
+	c.UI.Info(fmt.Sprintf("Creating virtualenv in %s", c.Trellis.Virtualenv.Path))
+
+	err := c.Trellis.Virtualenv.Create()
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error creating virtualenv: %s", err))
+		return 1
+	}
+
+	c.UI.Info("✓ Virtualenv created\n")
+
+	pip := execCommand("pip", "install", "-r", "requirements.txt")
+
+	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
+	s.Suffix = " Installing pip dependencies (pip install -r requirements.txt) ..."
+	s.FinalMSG = "✓ Dependencies installed\n"
+	s.Start()
+
+	err = pip.Run()
+
+	if err != nil {
+		s.Stop()
+		c.UI.Error(fmt.Sprintf("Error installing pip requirements", err))
+		return 1
+	}
+
+	s.Stop()
+
+	return 0
+}
+
+func (c *InitCommand) Synopsis() string {
+	return "Initializes an existing Trellis project"
+}
+
+func (c *InitCommand) Help() string {
+	helpText := `
+Usage: trellis init [options]
+
+Initializes an existing Trellis project to be managed by trellis-cli.
+The initialization process does two things:
+
+1. creates a virtual environment via virtualenv to manage dependencies
+2. installs dependencies via pip (specified by requirements.txt in your Trellis project)
+
+This command is idempotent meaning it can be run multiple times without side-effects.
+
+  $ trellis init
+
+Options:
+  -h, --help  show this help
+`
+
+	return strings.TrimSpace(helpText)
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/cli"
+	"trellis-cli/trellis"
+)
+
+func TestInitRunValidations(t *testing.T) {
+	ui := cli.NewMockUi()
+
+	cases := []struct {
+		name            string
+		projectDetected bool
+		args            []string
+		out             string
+		code            int
+	}{
+		{
+			"no_project",
+			false,
+			nil,
+			"No Trellis project detected",
+			1,
+		},
+		{
+			"too_many_args",
+			true,
+			[]string{"foo"},
+			"Error: too many arguments",
+			1,
+		},
+	}
+
+	for _, tc := range cases {
+		mockProject := &MockProject{tc.projectDetected}
+		trellis := trellis.NewTrellis(mockProject)
+		initCommand := &InitCommand{ui, trellis}
+
+		code := initCommand.Run(tc.args)
+
+		if code != tc.code {
+			t.Errorf("expected code %d to be %d", code, tc.code)
+		}
+
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+
+		if !strings.Contains(combined, tc.out) {
+			t.Errorf("expected output %q to contain %q", combined, tc.out)
+		}
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,7 +1,21 @@
 package cmd
 
 import (
+	"fmt"
+	"github.com/mitchellh/cli"
+	"os"
 	"os/exec"
+	"strings"
 )
 
 var execCommand = exec.Command
+
+func logCmd(cmd *exec.Cmd, ui cli.Ui, output bool) {
+	cmd.Stderr = os.Stderr
+
+	if output {
+		cmd.Stdout = &cli.UiWriter{ui}
+	}
+
+	fmt.Println("Running command =>", strings.Join(cmd.Args, " "))
+}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -117,13 +117,12 @@ func (c *NewCommand) Run(args []string) int {
 	trellisVersion := github.DownloadLatestRelease("roots/trellis", path, trellisPath)
 	bedrockVersion := github.DownloadLatestRelease("roots/bedrock", path, filepath.Join(path, "site"))
 
-	// TODO: not necessary after we commit .trellis to trellis repo
-	//if addTrellisFile(trellisPath) != nil {
-	//c.UI.Error("Error writing .trellis.yml file")
-	//return 1
-	//}
-
 	os.Chdir(path)
+
+	if err := c.trellis.CreateConfigDir(); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
 
 	if err := c.trellis.LoadProject(); err != nil {
 		c.UI.Error(err.Error())

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -19,14 +19,15 @@ import (
 )
 
 type NewCommand struct {
-	UI         cli.Ui
-	CliVersion string
-	flags      *flag.FlagSet
-	trellis    *trellis.Trellis
-	force      bool
-	name       string
-	host       string
-	vaultPass  string
+	UI             cli.Ui
+	CliVersion     string
+	flags          *flag.FlagSet
+	trellis        *trellis.Trellis
+	force          bool
+	name           string
+	host           string
+	skipVirtualenv bool
+	vaultPass      string
 }
 
 func NewNewCommand(ui cli.Ui, trellis *trellis.Trellis, version string) *NewCommand {
@@ -42,6 +43,7 @@ func (c *NewCommand) init() {
 	c.flags.StringVar(&c.name, "name", "", "Main site name (the domain name). Bypasses the name prompt if specified. Example: mydomain.com")
 	c.flags.StringVar(&c.host, "host", "", "Main site hostname. Bypasses the host prompt if specified. Example: mydomain.com or www.mydomain.com")
 	c.flags.StringVar(&c.vaultPass, "vault-pass", ".vault_pass", "Path for the generated Vault pass file")
+	c.flags.BoolVar(&c.skipVirtualenv, "skip-virtualenv", false, "Skip creating a new virtual environment for this project")
 }
 
 func (c *NewCommand) Run(args []string) int {
@@ -129,8 +131,10 @@ func (c *NewCommand) Run(args []string) int {
 		return 1
 	}
 
-	initCommand := &InitCommand{UI: c.UI, Trellis: c.trellis}
-	initCommand.Run([]string{})
+	if !c.skipVirtualenv {
+		initCommand := &InitCommand{UI: c.UI, Trellis: c.trellis}
+		initCommand.Run([]string{})
+	}
 
 	// Update default configs
 	for env, config := range c.trellis.Environments {
@@ -198,11 +202,12 @@ Arguments:
   PATH  Path to create new project in
 
 Options:
-      --force       (default: false) Forces the creation of the project even if the target path is not empty
-      --name        Main site name (the domain name). Bypasses the name prompt if specified. Example: mydomain.com
-      --host        Main site hostname. Bypasses the host prompt if specified. Example: mydomain.com or www.mydomain.com
-      --vault-pass  (default: .vault_pass) Path for the generated Vault pass file
-  -h, --help        show this help
+      --force            (default: false) Forces the creation of the project even if the target path is not empty
+      --name             Main site name (the domain name). Bypasses the name prompt if specified. Example: mydomain.com
+      --host             Main site hostname. Bypasses the host prompt if specified. Example: mydomain.com or www.mydomain.com
+      --skip-virtualenv  (default: false) Skip creating a new virtual environment for this project
+      --vault-pass       (default: .vault_pass) Path for the generated Vault pass file
+  -h, --help             show this help
 `
 
 	return strings.TrimSpace(helpText)

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -121,11 +121,6 @@ func (c *NewCommand) Run(args []string) int {
 
 	os.Chdir(path)
 
-	if err := c.trellis.CreateConfigDir(); err != nil {
-		c.UI.Error(err.Error())
-		return 1
-	}
-
 	if err := c.trellis.LoadProject(); err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -130,6 +130,9 @@ func (c *NewCommand) Run(args []string) int {
 		return 1
 	}
 
+	initCommand := &InitCommand{UI: c.UI, Trellis: c.trellis}
+	initCommand.Run([]string{})
+
 	// Update default configs
 	for env, config := range c.trellis.Environments {
 		c.trellis.UpdateDefaultConfig(config, c.name, c.host, env)

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -117,10 +117,11 @@ func (c *NewCommand) Run(args []string) int {
 	trellisVersion := github.DownloadLatestRelease("roots/trellis", path, trellisPath)
 	bedrockVersion := github.DownloadLatestRelease("roots/bedrock", path, filepath.Join(path, "site"))
 
-	if addTrellisFile(trellisPath) != nil {
-		c.UI.Error("Error writing .trellis.yml file")
-		return 1
-	}
+	// TODO: not necessary after we commit .trellis to trellis repo
+	//if addTrellisFile(trellisPath) != nil {
+	//c.UI.Error("Error writing .trellis.yml file")
+	//return 1
+	//}
 
 	os.Chdir(path)
 

--- a/github/main.go
+++ b/github/main.go
@@ -26,6 +26,8 @@ func DownloadLatestRelease(repo string, path string, dest string) string {
 	archivePath := fmt.Sprintf("%s.zip", release.Version)
 
 	err := DownloadFile(archivePath, release.ZipUrl)
+	defer os.Remove(archivePath)
+
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -45,14 +47,9 @@ func DownloadLatestRelease(repo string, path string, dest string) string {
 		err := os.Rename(dir, dest)
 
 		if err != nil {
+			os.RemoveAll(dir)
 			log.Fatal(err)
 		}
-	}
-
-	err = os.Remove(archivePath)
-
-	if err != nil {
-		log.Fatal(err)
 	}
 
 	return release.Version

--- a/github/main.go
+++ b/github/main.go
@@ -1,0 +1,100 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mholt/archiver"
+)
+
+type Release struct {
+	Version string `json:"tag_name"`
+	ZipUrl  string `json:"zipball_url"`
+}
+
+func DownloadLatestRelease(repo string, path string, dest string) string {
+	release := FetchLatestRelease(repo)
+
+	os.Chdir(path)
+	archivePath := fmt.Sprintf("%s.zip", release.Version)
+
+	err := DownloadFile(archivePath, release.ZipUrl)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := archiver.Unarchive(archivePath, path); err != nil {
+		log.Fatal(err)
+	}
+
+	org := strings.Split(repo, "/")[0]
+	dirs, _ := filepath.Glob(fmt.Sprintf("%s-*", org))
+
+	if len(dirs) == 0 {
+		log.Fatalln("Error: extracted release zip did not contain the expected directory")
+	}
+
+	for _, dir := range dirs {
+		err := os.Rename(dir, dest)
+
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	err = os.Remove(archivePath)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return release.Version
+}
+
+func FetchLatestRelease(repo string) Release {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", repo)
+	resp, err := http.Get(url)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	release := Release{}
+
+	if err = json.Unmarshal(body, &release); err != nil {
+		log.Fatal(err)
+	}
+
+	return release
+}
+
+func DownloadFile(filepath string, url string) error {
+	out, err := os.Create(filepath)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -47,6 +47,9 @@ func main() {
 		"droplet create": func() (cli.Command, error) {
 			return cmd.NewDropletCreateCommand(ui, trellis), nil
 		},
+		"exec": func() (cli.Command, error) {
+			return &cmd.ExecCommand{UI: ui, Trellis: trellis}, nil
+		},
 		"galaxy": func() (cli.Command, error) {
 			return &cmd.GalaxyCommand{UI: ui, Trellis: trellis}, nil
 		},

--- a/main.go
+++ b/main.go
@@ -56,6 +56,9 @@ func main() {
 		"info": func() (cli.Command, error) {
 			return &cmd.InfoCommand{UI: ui, Trellis: trellis}, nil
 		},
+		"init": func() (cli.Command, error) {
+			return &cmd.InitCommand{UI: ui, Trellis: trellis}, nil
+		},
 		"new": func() (cli.Command, error) {
 			return cmd.NewNewCommand(ui, trellis, c.Version), nil
 		},

--- a/trellis/detect.go
+++ b/trellis/detect.go
@@ -41,8 +41,14 @@ func (p *Project) Detect(path string) (projectPath string, ok bool) {
 func (p *Project) detectTrellisCLIProject(path string) bool {
 	trellisPath := filepath.Join(path, "trellis")
 	sitePath := filepath.Join(path, "site")
+	configPath := filepath.Join(trellisPath, ConfigDir)
 
 	trellisDir, err := os.Stat(trellisPath)
+	if err != nil {
+		return false
+	}
+
+	configDir, err := os.Stat(configPath)
 	if err != nil {
 		return false
 	}
@@ -52,10 +58,8 @@ func (p *Project) detectTrellisCLIProject(path string) bool {
 		return false
 	}
 
-	if trellisDir.Mode().IsDir() && siteDir.Mode().IsDir() {
-		if _, err := os.Stat(filepath.Join(trellisPath, ".trellis.yml")); err == nil {
-			return true
-		}
+	if trellisDir.Mode().IsDir() && siteDir.Mode().IsDir() && configDir.Mode().IsDir() {
+		return true
 	}
 
 	return false

--- a/trellis/detect_test.go
+++ b/trellis/detect_test.go
@@ -77,7 +77,7 @@ func TestDetectTrellisProjectStructure(t *testing.T) {
 	os.Mkdir(trellisDir, 0700)
 	os.Mkdir(siteDir, 0700)
 
-	ioutil.WriteFile(filepath.Join(trellisDir, ".trellis.yml"), []byte{}, 0666)
+	os.Mkdir(filepath.Join(trellisDir, ConfigDir), 0700)
 
 	devDir := filepath.Join(trellisDir, "group_vars", "development")
 	os.MkdirAll(devDir, 0700)

--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -12,10 +12,14 @@ import (
 	"strings"
 )
 
+const ConfigDir string = ".trellis"
+
 type Trellis struct {
 	detector     Detector
 	Environments map[string]*Config
+	ConfigPath   string
 	Path         string
+	Virtualenv   *Virtualenv
 }
 
 func NewTrellis(d Detector) *Trellis {
@@ -50,6 +54,9 @@ func (t *Trellis) LoadProject() error {
 	}
 
 	t.Path = path
+	t.ConfigPath = filepath.Join(path, ConfigDir)
+	t.Virtualenv = NewVirtualenv(t.ConfigPath)
+
 	os.Chdir(t.Path)
 
 	configPaths, _ := filepath.Glob("group_vars/*/wordpress_sites.yml")
@@ -63,6 +70,10 @@ func (t *Trellis) LoadProject() error {
 		envs[i] = envName
 
 		t.Environments[envName] = t.ParseConfig(p)
+	}
+
+	if t.Virtualenv.Initialized() {
+		t.Virtualenv.Activate()
 	}
 
 	return nil

--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -36,14 +36,14 @@ func (t *Trellis) Detect(path string) (projectPath string, ok bool) {
 }
 
 func (t *Trellis) CreateConfigDir() error {
-	_, err := os.Stat(ConfigDir)
+	_, err := os.Stat(t.ConfigPath)
 
 	if os.IsExist(err) {
 		return nil
 	}
 
 	if os.IsNotExist(err) {
-		return os.Mkdir(ConfigDir, 0755)
+		return os.Mkdir(t.ConfigPath, 0755)
 	}
 
 	return nil

--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -35,6 +35,20 @@ func (t *Trellis) Detect(path string) (projectPath string, ok bool) {
 	return t.detector.Detect(path)
 }
 
+func (t *Trellis) CreateConfigDir() error {
+	_, err := os.Stat(ConfigDir)
+
+	if os.IsExist(err) {
+		return nil
+	}
+
+	if os.IsNotExist(err) {
+		return os.Mkdir(ConfigDir, 0755)
+	}
+
+	return nil
+}
+
 /*
 Loads a Trellis project.
 If a project is detected, the wordpress_sites config files are parsed and

--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -86,8 +86,10 @@ func (t *Trellis) LoadProject() error {
 		t.Environments[envName] = t.ParseConfig(p)
 	}
 
-	if t.Virtualenv.Initialized() {
-		t.Virtualenv.Activate()
+	if os.Getenv("TRELLIS_VENV") != "false" {
+		if t.Virtualenv.Initialized() {
+			t.Virtualenv.Activate()
+		}
 	}
 
 	return nil

--- a/trellis/virtualenv.go
+++ b/trellis/virtualenv.go
@@ -1,0 +1,82 @@
+package trellis
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"trellis-cli/github"
+)
+
+const VirtualenvDir string = "virtualenv"
+const EnvName string = "VIRTUALENV"
+
+type Virtualenv struct {
+	Path    string
+	BinPath string
+}
+
+func NewVirtualenv(path string) *Virtualenv {
+	return &Virtualenv{
+		Path:    filepath.Join(path, VirtualenvDir),
+		BinPath: filepath.Join(path, VirtualenvDir, "bin"),
+	}
+}
+
+func (v *Virtualenv) Activate() {
+	os.Setenv(EnvName, v.Path)
+	os.Setenv("PATH", fmt.Sprintf("%s/bin:$PATH", v.Path))
+}
+
+func (v *Virtualenv) Active() bool {
+	return v.BinPath == os.Getenv(EnvName)
+}
+
+func (v *Virtualenv) Create() (err error) {
+	// TODO: error if not installed? or install
+	_, cmd := v.Installed()
+
+	cmd.Args = append(cmd.Args, v.Path)
+
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	v.Activate()
+	return nil
+}
+
+func (v *Virtualenv) Initialized() bool {
+	if _, err := os.Stat(filepath.Join(v.BinPath, "python")); os.IsNotExist(err) {
+		return false
+	}
+
+	if _, err := os.Stat(filepath.Join(v.BinPath, "pip")); os.IsNotExist(err) {
+		return false
+	}
+
+	return true
+}
+
+func (v *Virtualenv) Install(path string) string {
+	installPath := github.DownloadLatestRelease("pypa/virtualenv", os.TempDir(), path)
+	return installPath
+}
+
+func (v *Virtualenv) Installed() (ok bool, cmd *exec.Cmd) {
+	path, err := exec.LookPath("python3")
+	if err == nil {
+		return true, exec.Command(path, "-m", "venv")
+	}
+
+	path, err = exec.LookPath("virtualenv")
+	if err == nil {
+		return true, exec.Command(path)
+	}
+
+	// TODO: check for local virtualenv installed by trellis-cli
+
+	return false, nil
+}

--- a/trellis/virtualenv.go
+++ b/trellis/virtualenv.go
@@ -14,8 +14,9 @@ const VirtualenvDir string = "virtualenv"
 const EnvName string = "VIRTUALENV"
 
 type Virtualenv struct {
-	Path    string
-	BinPath string
+	Path       string
+	BinPath    string
+	OldPathEnv string
 }
 
 func NewVirtualenv(path string) *Virtualenv {
@@ -26,12 +27,13 @@ func NewVirtualenv(path string) *Virtualenv {
 }
 
 func (v *Virtualenv) Activate() {
+	v.OldPathEnv = os.Getenv("PATH")
 	os.Setenv(EnvName, v.Path)
-	os.Setenv("PATH", fmt.Sprintf("%s/bin:$PATH", v.Path))
+	os.Setenv("PATH", fmt.Sprintf("%s:$PATH", v.BinPath))
 }
 
 func (v *Virtualenv) Active() bool {
-	return v.BinPath == os.Getenv(EnvName)
+	return os.Getenv(EnvName) == v.Path
 }
 
 func (v *Virtualenv) Create() (err error) {
@@ -49,6 +51,11 @@ func (v *Virtualenv) Create() (err error) {
 
 	v.Activate()
 	return nil
+}
+
+func (v *Virtualenv) Deactivate() {
+	os.Unsetenv(EnvName)
+	os.Setenv("PATH", v.OldPathEnv)
 }
 
 func (v *Virtualenv) LocalPath() string {

--- a/trellis/virtualenv.go
+++ b/trellis/virtualenv.go
@@ -39,6 +39,10 @@ func (v *Virtualenv) Create() (err error) {
 
 	cmd.Args = append(cmd.Args, v.Path)
 
+	if v.Initialized() {
+		return nil
+	}
+
 	err = cmd.Run()
 	if err != nil {
 		return err

--- a/trellis/virtualenv.go
+++ b/trellis/virtualenv.go
@@ -11,7 +11,7 @@ import (
 )
 
 const VirtualenvDir string = "virtualenv"
-const EnvName string = "VIRTUALENV"
+const EnvName string = "VIRTUAL_ENV"
 
 type Virtualenv struct {
 	Path       string
@@ -41,6 +41,7 @@ func (v *Virtualenv) Create() (err error) {
 	cmd.Args = append(cmd.Args, v.Path)
 
 	if v.Initialized() {
+		v.Activate()
 		return nil
 	}
 

--- a/trellis/virtualenv_test.go
+++ b/trellis/virtualenv_test.go
@@ -29,8 +29,8 @@ func TestActivateSetsEnv(t *testing.T) {
 
 	venv.Activate()
 
-	if os.Getenv("VIRTUALENV") != "trellis/virtualenv" {
-		t.Error("expected VIRTUALENV env var to set")
+	if os.Getenv("VIRTUAL_ENV") != "trellis/virtualenv" {
+		t.Error("expected VIRTUAL_ENV env var to set")
 	}
 
 	if os.Getenv("PATH") != "trellis/virtualenv/bin:$PATH" {

--- a/trellis/virtualenv_test.go
+++ b/trellis/virtualenv_test.go
@@ -1,0 +1,228 @@
+package trellis
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewVirtualenv(t *testing.T) {
+	venv := NewVirtualenv("trellis")
+	path := "trellis/virtualenv"
+	binPath := "trellis/virtualenv/bin"
+
+	if venv.Path != path {
+		t.Errorf("expected path to be %s, but got %s", venv.Path, path)
+	}
+
+	if venv.BinPath != binPath {
+		t.Errorf("expected path to be %s, but got %s", venv.Path, binPath)
+	}
+}
+
+func TestActivateSetsEnv(t *testing.T) {
+	venv := NewVirtualenv("trellis")
+	originalPath := os.Getenv("PATH")
+
+	venv.Activate()
+
+	if os.Getenv("VIRTUALENV") != "trellis/virtualenv" {
+		t.Error("expected VIRTUALENV env var to set")
+	}
+
+	if os.Getenv("PATH") != "trellis/virtualenv/bin:$PATH" {
+		t.Error("expected PATH to contain bin path")
+	}
+
+	if venv.OldPathEnv != originalPath {
+		t.Error("expected OldPathEnv to be the original PATH")
+	}
+
+	venv.Deactivate()
+}
+
+func TestActive(t *testing.T) {
+	venv := NewVirtualenv("trellis")
+
+	if venv.Active() {
+		t.Error("expected virtualenv to be inactive")
+	}
+
+	venv.Activate()
+
+	if !venv.Active() {
+		t.Error("expected virtualenv to be active")
+	}
+}
+
+func TestDeactive(t *testing.T) {
+	venv := NewVirtualenv("trellis")
+	venv.Activate()
+	venv.Deactivate()
+
+	if os.Getenv("VIRTUALENV") != "" {
+		t.Error("Expected VIRTUALENV to be empty")
+	}
+
+	if os.Getenv("PATH") != venv.OldPathEnv {
+		t.Error("Expected PATH to be reset")
+	}
+}
+
+func TestLocalPath(t *testing.T) {
+	venv := NewVirtualenv("trellis")
+	originalConfigHome := os.Getenv("XDG_CONFIG_HOME")
+	os.Unsetenv("XDG_CONFIG_HOME")
+	defer os.Setenv("XDG_CONFIG_HOME", originalConfigHome)
+
+	homeDir, _ := os.UserHomeDir()
+
+	localPath := venv.LocalPath()
+
+	if localPath != filepath.Join(homeDir, ".local/share/trellis/virtualenv") {
+		t.Error("Expected LocalPath to default to $USER/.local/share")
+	}
+
+	os.Setenv("XDG_CONFIG_HOME", "mydir")
+	defer os.Setenv("XDG_CONFIG_HOME", originalConfigHome)
+
+	localPath = venv.LocalPath()
+
+	if localPath != filepath.Join("mydir", "trellis/virtualenv") {
+		t.Error("Expected LocalPath to use XDG_CONFIG_HOME when set")
+	}
+}
+
+func TestInitialized(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "trellis")
+	defer os.RemoveAll(tempDir)
+
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	venv := NewVirtualenv(tempDir)
+
+	if venv.Initialized() {
+		t.Error("Expected to be uniniatlized")
+	}
+
+	os.MkdirAll(venv.BinPath, os.ModePerm)
+	testCreateFile(t, filepath.Join(venv.BinPath, "python"))()
+	testCreateFile(t, filepath.Join(venv.BinPath, "pip"))()
+
+	if !venv.Initialized() {
+		t.Error("Expected to be initialized")
+	}
+}
+
+func TestInstalled(t *testing.T) {
+	defer testSetEnv("PATH", "")()
+	defer testSetEnv("XDG_CONFIG_HOME", "none")()
+
+	venv := NewVirtualenv("foo")
+
+	ok, _ := venv.Installed()
+
+	if ok {
+		t.Error("Expected to be uninstalled")
+	}
+}
+
+func TestInstalledPython3(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "trellis")
+	defer os.RemoveAll(tempDir)
+
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	defer testSetEnv("PATH", tempDir)()
+
+	pythonPath := filepath.Join(tempDir, "python3")
+	os.OpenFile(pythonPath, os.O_CREATE, 0555)
+
+	venv := NewVirtualenv(tempDir)
+
+	ok, cmd := venv.Installed()
+
+	if !ok {
+		t.Error("Expected to be installed")
+	}
+
+	if strings.Join(cmd.Args, " ") != fmt.Sprintf("%s -m venv", pythonPath) {
+		t.Error("Expected args incorrect")
+	}
+}
+
+func TestInstalledVirtualenv(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "trellis")
+	defer os.RemoveAll(tempDir)
+
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	defer testSetEnv("PATH", tempDir)()
+
+	venvPath := filepath.Join(tempDir, "virtualenv")
+	os.OpenFile(venvPath, os.O_CREATE, 0555)
+
+	venv := NewVirtualenv(tempDir)
+
+	ok, cmd := venv.Installed()
+
+	if !ok {
+		t.Error("Expected to be installed")
+	}
+
+	if strings.Join(cmd.Args, " ") != venvPath {
+		t.Error("Expected args incorrect")
+	}
+}
+
+func TestInstalledLocalVirtualenv(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "trellis")
+	defer os.RemoveAll(tempDir)
+
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	defer testSetEnv("PATH", "")()
+	defer testSetEnv("XDG_CONFIG_HOME", tempDir)()
+
+	venv := NewVirtualenv(tempDir)
+	localVenvPath := filepath.Join(venv.LocalPath(), "virtualenv.py")
+	os.MkdirAll(venv.LocalPath(), os.ModePerm)
+	testCreateFile(t, localVenvPath)()
+
+	ok, cmd := venv.Installed()
+
+	if !ok {
+		t.Error("Expected to be installed")
+	}
+
+	if strings.Join(cmd.Args, " ") != fmt.Sprintf("python %s", localVenvPath) {
+		t.Error("Expected args incorrect")
+	}
+}
+
+func testCreateFile(t *testing.T, path string) func() {
+	file, err := os.Create(path)
+
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	return func() { file.Close() }
+}
+
+func testSetEnv(env string, value string) func() {
+	old := os.Getenv(env)
+	os.Setenv(env, value)
+	return func() { os.Setenv(env, old) }
+}


### PR DESCRIPTION
trellis-cli exists to make Trellis easier to install, use, and manage. So far all the features have made it easier to create new projects and manage them, but nothing to help install Trellis' initial requirements. We've seen people struggle to use the proper python, install `pip`, install the correct versions of Ansible, etc.

This PR adds [virtualenv](https://virtualenv.pypa.io/en/latest/) support which is a tool to create isolated Python environments. The idea is that a Trellis user *only* needs Python installed and trellis-cli will take care of the rest. Thankfully most OS' have Python installed by default, so nothing else will be needed.

High-level workflow:

1. when creating a project with `new`, a virtualenv is created per project and activated
2. a new `init` command will "initialize" a project with virtualenv
3. any trellis-cli command in a project will automatically activate virtualenv and use its `bin` dir (as part of `$PATH`

trellis-cli will attempt the following to use virtualenv:
1. if python3 is installed: use built-in `venv` module
2. if `virtualenv` exists then just use it directly
3. finally install virtualenv locally and use it

Note: this relies on changes in https://github.com/roots/trellis/pull/1100