### PR TITLE
[WIP] Homebrew: Allow install from HEAD

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,8 +38,16 @@ brews:
     folder: Formula
     homepage:  https://roots.io/trellis
     description: A CLI to manage Trellis projects
+    custom_block: |
+      head "https://github.com/roots/trellis-cli.git"
+      depends_on "go" => :build
     install: |
-      bin.install "trellis"
+      output = "trellis"
+      if build.head?
+        output = "bin/" + output
+        system "go", "build", "-o", output
+      end
+      bin.install output
     test: |
       system "#{bin}/trellis --autocomplete-install"
       system "#{bin}/trellis -v"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ trellis-cli provides binary releases for a variety of OSes. These binary version
 4. Make sure the above path is in your `$PATH`
 5. Run `trellis --autocomplete-install` to install shell autocompletions
 
+## Installation (Unstable)
+
+```bash
+# Cleanup preivous versions
+brew uninstall roots/tap/trellis-cli
+
+# Install
+brew install --debug --HEAD roots/tap/trellis-cli
+
+# Upgrade
+brew upgrade --fetch-HEAD roots/tap/trellis-cli
+```
+
 ## Usage
 
 Run `trellis` for the complete usage and help.


### PR DESCRIPTION
https://github.com/TangRufus/homebrew-tap/blob/feac3f9776e86d7e65910b7a5cafd00e30b56e76/Formula/trellis-cli.rb works, but not sure how to test goreleaser generates the formula as expected.