### PR TITLE
Rename Ansible role file for `galaxy install` cmd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367 &&
 # Trellis
 RUN git clone https://github.com/roots/trellis.git "${TEST_DUMMY}/trellis" && \
     cd "${TEST_DUMMY}/trellis" && \
-    ansible-galaxy install -r requirements.yml
+    ansible-galaxy install -r galaxy.yml
 
 # Bedrock
 RUN mkdir -p "${TEST_DUMMY}/site" && \

--- a/cmd/galaxy_install.go
+++ b/cmd/galaxy_install.go
@@ -25,7 +25,7 @@ func (c *GalaxyInstallCommand) Run(args []string) int {
 		return 1
 	}
 
-	galaxyInstall := execCommand("ansible-galaxy", "install", "-r", "requirements.yml")
+	galaxyInstall := execCommand("ansible-galaxy", "install", "-r", "galaxy.yml")
 	logCmd(galaxyInstall, c.UI, true)
 	err := galaxyInstall.Run()
 

--- a/cmd/galaxy_install_test.go
+++ b/cmd/galaxy_install_test.go
@@ -72,7 +72,7 @@ func TestGalaxyInstallRun(t *testing.T) {
 		{
 			"default",
 			[]string{},
-			"ansible-galaxy install -r requirements.yml",
+			"ansible-galaxy install -r galaxy.yml",
 			0,
 		},
 	}


### PR DESCRIPTION
From `requirements.yml` to `galaxy.yml` as per Trellis v1.1.0 (specifically roots/trellis#1100).

It’s probably preferable to have it set the file name based on the Trellis version, since this change alone would break compatibility with Trellis versions prior to 1.1.0.