### PR TITLE
Skip loading an already loaded project

### DIFF
--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -37,8 +37,12 @@ If a project is detected, the wordpress_sites config files are parsed and
 the directory is changed to the project path.
 */
 func (t *Trellis) LoadProject() error {
-	wd, err := os.Getwd()
+	if t.Path != "" {
+		os.Chdir(t.Path)
+		return nil
+	}
 
+	wd, err := os.Getwd()
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
It turns out that the cli package runs all command autocomplete functions at boot. Since many command's autocomplete functions try to load a Trellis project, this means it attempts to load a project many times.

Checking if `Path` has been previously set speeds up runtime by about 50%!

Before: `trellis info  0.02s user 0.02s system 100% cpu 0.044 total`
After: `trellisinfo  0.01s user 0.01s system 87% cpu 0.025 total`