### PR TITLE
Bump golang to v1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.13
     steps:
       - run: go version
       - checkout
@@ -40,7 +40,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.13
     steps:
       - run: go version
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This docker image is for integration testing only.
 
-FROM golang:1.12-buster
+FROM golang:1.13-buster
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Supported commands so far:
 
 ## Development
 
-trellis-cli requires Go >= 1.12 (`brew install go` on macOS)
+trellis-cli requires Go >= 1.13 (`brew install go` on macOS)
 
 ```bash
 # Clone the repo


### PR DESCRIPTION
To fix [gorelaser not building error](https://circleci.com/gh/roots/trellis-cli/108?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)

Note: We need to publish new docker image after merging into master