### PR TITLE
Remove windows support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,7 +8,6 @@ builds:
   goos:
     - linux
     - darwin
-    - windows
   goarch:
     - 386
     - amd64
@@ -16,12 +15,8 @@ archive:
   replacements:
     darwin: Darwin
     linux: Linux
-    windows: Windows
     386: i386
     amd64: x86_64
-  format_overrides:
-    - goos: windows
-      format: zip
 checksum:
   name_template: '{{ .ProjectName }}_checksums.txt'
 changelog:


### PR DESCRIPTION
This is because `syscall.Exec` doesn't work on windows and `sys/unix.Exec` doesn't have a windows counterpart. See: https://github.com/roots/trellis-cli/pull/64

Until someone smarter than me make [`SyscallCommandExecutor`](https://github.com/roots/trellis-cli/blob/cb5abb0c32042c67567f476f22fb7afbbff4f89a/cmd/command.go#L16) works on windows, use WSL instead. 

Sorry windows users.