### PR TITLE
CircleCI: Dry run `goreleaser`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,11 +46,21 @@ jobs:
       - checkout
       - run: curl -sL https://git.io/goreleaser | bash
 
+  release-test:
+    docker:
+      - image: circleci/golang:1.13
+    steps:
+      - run: go version
+      - checkout
+      - run: curl -sL https://git.io/goreleaser | bash -s check
+      - run: curl -sL https://git.io/goreleaser | bash -s -- --snapshot --skip-publish --rm-dist
+
 workflows:
   test:
     jobs:
       - test
       - integration-test
+      - release-test
       - release:
           filters:
             branches:


### PR DESCRIPTION
Redeem from https://github.com/roots/trellis-cli/pull/67 (golang version was not the issue).

This pull request adds `goreleaser check` and `goreleaser --snapshot --skip-publish --rm-dist` to check compilation issues.

The command is taken from https://goreleaser.com/quick-start/

> You can test the configuration at any time by running GoReleaser with a few extra parameters to not require a version tag, skip publishing to GitHub, and remove any already-built files:
>    $ goreleaser --snapshot --skip-publish --rm-dist
> -- https://goreleaser.com/quick-start/