### PR TITLE
Default to virtualenv if installed

### DIFF
--- a/trellis/virtualenv.go
+++ b/trellis/virtualenv.go
@@ -100,14 +100,14 @@ func (v *Virtualenv) Install() string {
 }
 
 func (v *Virtualenv) Installed() (ok bool, cmd *exec.Cmd) {
-	path, err := exec.LookPath("python3")
-	if err == nil {
-		return true, exec.Command(path, "-m", "venv")
-	}
-
-	path, err = exec.LookPath("virtualenv")
+	path, err := exec.LookPath("virtualenv")
 	if err == nil {
 		return true, exec.Command(path)
+	}
+
+	path, err = exec.LookPath("python3")
+	if err == nil {
+		return true, exec.Command(path, "-m", "venv")
 	}
 
 	localVenvPath := filepath.Join(v.LocalPath(), "virtualenv.py")


### PR DESCRIPTION
Previously this selected python3's built-in `venv` feature first if python3 is detected.

Now this will select `virtualenv` first if installed. This gives users more control and allows them to specify a python version via the `VIRTUALENV_PYTHON` env var which `virtualenv` supports.

This is one solution to the issue encountered in https://discourse.roots.io/t/ansible-upgrade-breaks-access-to-all-other-trellis-deploys/16733/16