### PR TITLE
Fix virtualenv PATH env var

### DIFF
--- a/trellis/virtualenv.go
+++ b/trellis/virtualenv.go
@@ -29,7 +29,7 @@ func NewVirtualenv(path string) *Virtualenv {
 func (v *Virtualenv) Activate() {
 	v.OldPathEnv = os.Getenv("PATH")
 	os.Setenv(EnvName, v.Path)
-	os.Setenv("PATH", fmt.Sprintf("%s:$PATH", v.BinPath))
+	os.Setenv("PATH", fmt.Sprintf("%s:%s", v.BinPath, v.OldPathEnv))
 }
 
 func (v *Virtualenv) Active() bool {

--- a/trellis/virtualenv_test.go
+++ b/trellis/virtualenv_test.go
@@ -33,7 +33,7 @@ func TestActivateSetsEnv(t *testing.T) {
 		t.Error("expected VIRTUAL_ENV env var to set")
 	}
 
-	if os.Getenv("PATH") != "trellis/virtualenv/bin:$PATH" {
+	if os.Getenv("PATH") != fmt.Sprintf("trellis/virtualenv/bin:%s", originalPath) {
 		t.Error("expected PATH to contain bin path")
 	}
 


### PR DESCRIPTION
`$PATH` isn't expanded as usual so instead this just uses the actual full value we already have.