### PR TITLE
Use ansible-playbook for deploy command

### DIFF
--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -67,7 +67,7 @@ func TestDeployRunValidations(t *testing.T) {
 	for _, tc := range cases {
 		mockProject := &MockProject{tc.projectDetected}
 		trellis := trellis.NewTrellis(mockProject)
-		deployCommand := &DeployCommand{ui, trellis}
+		deployCommand := NewDeployCommand(ui, trellis)
 
 		code := deployCommand.Run(tc.args)
 
@@ -88,7 +88,7 @@ func TestDeployRun(t *testing.T) {
 	ui := cli.NewMockUi()
 	project := &trellis.Project{}
 	trellis := trellis.NewTrellis(project)
-	deployCommand := &DeployCommand{ui, trellis}
+	deployCommand := NewDeployCommand(ui, trellis)
 
 	execCommand = mockExecCommand
 	defer func() { execCommand = exec.Command }()
@@ -102,13 +102,19 @@ func TestDeployRun(t *testing.T) {
 		{
 			"default",
 			[]string{"development", "example.com"},
-			"./bin/deploy.sh development example.com",
+			`ansible-playbook deploy.yml -e "env=development site=example.com"`,
 			0,
 		},
 		{
 			"site_not_needed_in_defaut_case",
 			[]string{"development"},
-			"./bin/deploy.sh development example.com",
+			`ansible-playbook deploy.yml -e "env=development site=example.com"`,
+			0,
+		},
+		{
+			"with_extra_vars",
+			[]string{"-extra-vars", "k=v foo=bar", "development"},
+			`ansible-playbook deploy.yml -e "env=development site=example.com k=v foo=bar"`,
 			0,
 		},
 	}

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 			return &cmd.CheckCommand{UI: ui, Trellis: trellis}, nil
 		},
 		"deploy": func() (cli.Command, error) {
-			return &cmd.DeployCommand{UI: ui, Trellis: trellis}, nil
+			return cmd.NewDeployCommand(ui, trellis), nil
 		},
 		"dotenv": func() (cli.Command, error) {
 			return &cmd.DotEnvCommand{UI: ui, Trellis: trellis}, nil


### PR DESCRIPTION
We should use `ansible-playbook deploy.yml` directly instead of going through `bin/deploy.sh`. Eventually that deploy script will be removed entirely from Trellis and users should use this CLI.

This also adds support for extra vars.