### PR TITLE
Remove unreachable file existence check

### DIFF
--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -38,10 +38,6 @@ func (t *Trellis) Detect(path string) (projectPath string, ok bool) {
 func (t *Trellis) CreateConfigDir() error {
 	_, err := os.Stat(t.ConfigPath)
 
-	if os.IsExist(err) {
-		return nil
-	}
-
 	if os.IsNotExist(err) {
 		return os.Mkdir(t.ConfigPath, 0755)
 	}

--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -36,10 +36,8 @@ func (t *Trellis) Detect(path string) (projectPath string, ok bool) {
 }
 
 func (t *Trellis) CreateConfigDir() error {
-	_, err := os.Stat(t.ConfigPath)
-
-	if os.IsNotExist(err) {
-		return os.Mkdir(t.ConfigPath, 0755)
+	if err := os.Mkdir(t.ConfigPath, 0755); err != nil && !os.IsExist(err) {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Stat returns nil for error if file exists, so that check will never run, removing it keeps the same functionality.