### PR TITLE
Extract `validateArgumentCount`

### DIFF
--- a/cmd/alias.go
+++ b/cmd/alias.go
@@ -46,10 +46,9 @@ func (c *AliasCommand) Run(args []string) int {
 
 	args = c.flags.Args()
 
-	switch len(args) {
-	case 0:
-	default:
-		c.UI.Error(fmt.Sprintf("Error: too many arguments (expected 0, got %d)\n", len(args)))
+	argCountErr := validateArgumentCount(args, 0, 0)
+	if argCountErr != nil {
+		c.UI.Error(argCountErr.Error())
 		c.UI.Output(c.Help())
 		return 1
 	}

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -33,7 +33,9 @@ var Requirements = []trellis.Requirement{
 }
 
 func (c *CheckCommand) Run(args []string) int {
-	if len(args) > 0 {
+	argCountErr := validateArgumentCount(args, 0, 0)
+	if argCountErr != nil {
+		c.UI.Error(argCountErr.Error())
 		c.UI.Output(c.Help())
 		return 1
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -50,6 +50,7 @@ func (c *DeployCommand) Run(args []string) int {
 	}
 
 	environment := args[0]
+
 	siteName := ""
 	if len(args) == 2 {
 		siteName = args[1]

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -36,28 +36,23 @@ func (c *DeployCommand) Run(args []string) int {
 		return 1
 	}
 
-	var environment string
-	var siteName string
-
 	if err := c.flags.Parse(args); err != nil {
 		return 1
 	}
 
 	args = c.flags.Args()
 
-	switch len(args) {
-	case 0:
+	argCountErr := validateArgumentCount(args, 1, 1)
+	if argCountErr != nil {
+		c.UI.Error(argCountErr.Error())
 		c.UI.Output(c.Help())
 		return 1
-	case 1:
-		environment = args[0]
-	case 2:
-		environment = args[0]
+	}
+
+	environment := args[0]
+	siteName := ""
+	if len(args) == 2 {
 		siteName = args[1]
-	default:
-		c.UI.Error(fmt.Sprintf("Error: too many arguments (expected 2, got %d)\n", len(args)))
-		c.UI.Output(c.Help())
-		return 1
 	}
 
 	_, ok := c.Trellis.Environments[environment]

--- a/cmd/dot_env.go
+++ b/cmd/dot_env.go
@@ -20,17 +20,16 @@ func (c *DotEnvCommand) Run(args []string) int {
 		return 1
 	}
 
-	var environment string
-
-	switch len(args) {
-	case 0:
-		environment = "development"
-	case 1:
-		environment = args[0]
-	default:
-		c.UI.Error(fmt.Sprintf("Error: too many arguments (expected 0 or 1, got %d)\n", len(args)))
+	argCountErr := validateArgumentCount(args, 0, 1)
+	if argCountErr != nil {
+		c.UI.Error(argCountErr.Error())
 		c.UI.Output(c.Help())
 		return 1
+	}
+
+	environment := "development"
+	if len(args) == 1 {
+		environment = args[0]
 	}
 
 	_, ok := c.Trellis.Environments[environment]

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"strings"
 
 	"trellis-cli/trellis"
@@ -20,10 +19,9 @@ func (c *DownCommand) Run(args []string) int {
 		return 1
 	}
 
-	switch len(args) {
-	case 0:
-	default:
-		c.UI.Error(fmt.Sprintf("Error: too many arguments (expected 0, got %d)\n", len(args)))
+	argCountErr := validateArgumentCount(args, 0, 0)
+	if argCountErr != nil {
+		c.UI.Error(argCountErr.Error())
 		c.UI.Output(c.Help())
 		return 1
 	}

--- a/cmd/droplet_create.go
+++ b/cmd/droplet_create.go
@@ -57,25 +57,20 @@ func (c *DropletCreateCommand) Run(args []string) int {
 		return 1
 	}
 
-	var environment string
-
 	if err := c.flags.Parse(args); err != nil {
 		return 1
 	}
 
 	args = c.flags.Args()
 
-	switch len(args) {
-	case 0:
-		c.UI.Output(c.Help())
-		return 1
-	case 1:
-		environment = args[0]
-	default:
-		c.UI.Error(fmt.Sprintf("Error: too many arguments (expected 1, got %d)\n", len(args)))
+	argCountErr := validateArgumentCount(args, 0, 1)
+	if argCountErr != nil {
+		c.UI.Error(argCountErr.Error())
 		c.UI.Output(c.Help())
 		return 1
 	}
+
+	environment := args[0]
 
 	if environment == "development" {
 		c.UI.Error("create command only supports staging/production environments")

--- a/cmd/galaxy_install.go
+++ b/cmd/galaxy_install.go
@@ -20,8 +20,9 @@ func (c *GalaxyInstallCommand) Run(args []string) int {
 		return 1
 	}
 
-	if len(args) > 0 {
-		c.UI.Error(fmt.Sprintf("Error: too many arguments (expected 0, got %d)\n", len(args)))
+	argCountErr := validateArgumentCount(args, 0, 0)
+	if argCountErr != nil {
+		c.UI.Error(argCountErr.Error())
 		c.UI.Output(c.Help())
 		return 1
 	}

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -19,6 +19,13 @@ func (c *InfoCommand) Run(args []string) int {
 		return 1
 	}
 
+	argCountErr := validateArgumentCount(args, 0, 0)
+	if argCountErr != nil {
+		c.UI.Error(argCountErr.Error())
+		c.UI.Output(c.Help())
+		return 1
+	}
+
 	for name, config := range c.Trellis.Environments {
 		var siteNames []string
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -21,10 +21,9 @@ func (c *InitCommand) Run(args []string) int {
 		return 1
 	}
 
-	switch len(args) {
-	case 0:
-	default:
-		c.UI.Error(fmt.Sprintf("Error: too many arguments (expected 0, got %d)\n", len(args)))
+	argCountErr := validateArgumentCount(args, 0, 0)
+	if argCountErr != nil {
+		c.UI.Error(argCountErr.Error())
 		c.UI.Output(c.Help())
 		return 1
 	}

--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -38,26 +38,20 @@ func (c *ProvisionCommand) Run(args []string) int {
 		return 1
 	}
 
-	var environment string
-
 	if err := c.flags.Parse(args); err != nil {
 		return 1
 	}
 
 	args = c.flags.Args()
 
-	switch len(args) {
-	case 0:
-		c.UI.Error("Error: missing ENVIRONMENT argument\n")
-		c.UI.Output(c.Help())
-		return 1
-	case 1:
-		environment = args[0]
-	default:
-		c.UI.Error(fmt.Sprintf("Error: too many arguments (expected 1, got %d)\n", len(args)))
+	argCountErr := validateArgumentCount(args, 1, 0)
+	if argCountErr != nil {
+		c.UI.Error(argCountErr.Error())
 		c.UI.Output(c.Help())
 		return 1
 	}
+
+	environment := args[0]
 
 	_, ok := c.Trellis.Environments[environment]
 	if !ok {

--- a/cmd/provision_test.go
+++ b/cmd/provision_test.go
@@ -31,7 +31,7 @@ func TestProvisionRunValidations(t *testing.T) {
 			"no_args",
 			true,
 			nil,
-			"Error: missing ENVIRONMENT argument",
+			"Error: missing arguments (expected exactly 1, got 0)",
 			1,
 		},
 		{

--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -36,28 +36,24 @@ func (c *RollbackCommand) Run(args []string) int {
 		return 1
 	}
 
-	var environment string
-	var siteName string
-
 	if err := c.flags.Parse(args); err != nil {
 		return 1
 	}
 
 	args = c.flags.Args()
 
-	switch len(args) {
-	case 0:
+	argCountErr := validateArgumentCount(args, 1, 1)
+	if argCountErr != nil {
+		c.UI.Error(argCountErr.Error())
 		c.UI.Output(c.Help())
 		return 1
-	case 1:
-		environment = args[0]
-	case 2:
-		environment = args[0]
+	}
+
+	environment := args[0]
+
+	siteName := ""
+	if len(args) == 2 {
 		siteName = args[1]
-	default:
-		c.UI.Error(fmt.Sprintf("Error: too many arguments (expected 2, got %d)\n", len(args)))
-		c.UI.Output(c.Help())
-		return 1
 	}
 
 	_, ok := c.Trellis.Environments[environment]

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -22,24 +22,21 @@ func (c *SshCommand) Run(args []string) int {
 		return 1
 	}
 
-	var environment string
-	var siteName string
-	var user string
-
-	switch len(args) {
-	case 0:
-		c.UI.Output(c.Help())
-		return 1
-	case 1:
-		environment = args[0]
-	case 2:
-		environment = args[0]
-		siteName = args[1]
-	default:
-		c.UI.Error(fmt.Sprintf("Error: too many arguments (expected 2, got %d)\n", len(args)))
+	argCountErr := validateArgumentCount(args, 1, 1)
+	if argCountErr != nil {
+		c.UI.Error(argCountErr.Error())
 		c.UI.Output(c.Help())
 		return 1
 	}
+
+	environment := args[0]
+
+	siteName := ""
+	if len(args) == 2 {
+		siteName = args[1]
+	}
+
+	var user string
 
 	_, ok := c.Trellis.Environments[environment]
 	if !ok {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"flag"
-	"fmt"
 	"os"
 	"strings"
 
@@ -44,10 +43,9 @@ func (c *UpCommand) Run(args []string) int {
 
 	args = c.flags.Args()
 
-	switch len(args) {
-	case 0:
-	default:
-		c.UI.Error(fmt.Sprintf("Error: too many arguments (expected 0, got %d)\n", len(args)))
+	argCountErr := validateArgumentCount(args, 0, 0)
+	if argCountErr != nil {
+		c.UI.Error(argCountErr.Error())
 		c.UI.Output(c.Help())
 		return 1
 	}

--- a/cmd/valet_link.go
+++ b/cmd/valet_link.go
@@ -20,17 +20,16 @@ func (c *ValetLinkCommand) Run(args []string) int {
 		return 1
 	}
 
-	var environment string
-
-	switch len(args) {
-	case 0:
-		environment = "development"
-	case 1:
-		environment = args[0]
-	default:
-		c.UI.Error(fmt.Sprintf("Error: too many arguments (expected 0 or 1, got %d)\n", len(args)))
+	argCountErr := validateArgumentCount(args, 0, 1)
+	if argCountErr != nil {
+		c.UI.Error(argCountErr.Error())
 		c.UI.Output(c.Help())
 		return 1
+	}
+
+	environment := "development"
+	if len(args) == 1 {
+		environment = args[0]
 	}
 
 	config, ok := c.Trellis.Environments[environment]

--- a/cmd/validate_argument_count.go
+++ b/cmd/validate_argument_count.go
@@ -1,0 +1,20 @@
+package cmd
+
+import "fmt"
+
+func validateArgumentCount(args []string, requiredArgCount int, optionalArgCount int) (err error) {
+	argCount := len(args)
+
+	expectedCount := fmt.Sprintf("exactly %d", requiredArgCount)
+	if (optionalArgCount > 0) {
+		expectedCount = fmt.Sprintf("between %d and %d", requiredArgCount, requiredArgCount + optionalArgCount)
+	}
+
+	if argCount > requiredArgCount + optionalArgCount {
+		err = fmt.Errorf("Error: too many arguments (expected %s, got %d)\n", expectedCount, len(args))
+	} else if argCount < requiredArgCount {
+		err = fmt.Errorf("Error: missing arguments (expected %s, got %d)\n", expectedCount, len(args))
+	}
+
+	return
+}

--- a/cmd/validate_argument_count_test.go
+++ b/cmd/validate_argument_count_test.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateArgumentCount(t *testing.T) {
+	cases := []struct {
+		name             string
+		args             []string
+		requiredArgCount int
+		optionalArgCount int
+		expectedMessage  string
+	}{
+		{
+			"valid_without_optional",
+			[]string{"a", "b", "c"},
+			3,
+			0,
+			"",
+		},
+		{
+			"valid_with_optional",
+			[]string{"a", "b", "c"},
+			1,
+			2,
+			"",
+		},
+		{
+			"missing_without_optional",
+			[]string{"a", "b", "c"},
+			4,
+			0,
+			"missing arguments (expected exactly 4, got 3)",
+		},
+		{
+			"missing_with_optional",
+			[]string{"a", "b", "c"},
+			4,
+			2,
+			"missing arguments (expected between 4 and 6, got 3)",
+		},
+		{
+			"too_many_without_optional",
+			[]string{"a", "b", "c"},
+			2,
+			0,
+			"too many arguments (expected exactly 2, got 3)",
+		},
+		{
+			"too_many_with_optional",
+			[]string{"a", "b", "c"},
+			1,
+			1,
+			"too many arguments (expected between 1 and 2, got 3)",
+		},
+	}
+
+	for _, tc := range cases {
+		actual := validateArgumentCount(tc.args, tc.requiredArgCount, tc.optionalArgCount)
+
+		if "" == tc.expectedMessage && actual != nil {
+			t.Errorf("expected result to be valid, got %s", actual)
+		}
+
+		if "" != tc.expectedMessage && actual == nil {
+			t.Errorf("expected result to be invalid, got nil")
+		}
+
+		if "" != tc.expectedMessage && actual != nil {
+			if !strings.Contains(actual.Error(), tc.expectedMessage) {
+				t.Errorf("expected error to contains %s, got %s", tc.expectedMessage, actual)
+			}
+		}
+	}
+}

--- a/cmd/vault_decrypt.go
+++ b/cmd/vault_decrypt.go
@@ -42,21 +42,16 @@ func (c *VaultDecryptCommand) Run(args []string) int {
 
 	args = c.flags.Args()
 
-	var environment string
-	var files []string
-
-	switch len(args) {
-	case 0:
-		c.UI.Error("Error: missing ENVIRONMENT argument\n")
-		c.UI.Output(c.Help())
-		return 1
-	case 1:
-		environment = args[0]
-	default:
-		c.UI.Error(fmt.Sprintf("Error: too many arguments (expected 1, got %d)\n", len(args)))
+	argCountErr := validateArgumentCount(args, 1, 0)
+	if argCountErr != nil {
+		c.UI.Error(argCountErr.Error())
 		c.UI.Output(c.Help())
 		return 1
 	}
+
+	environment := args[0]
+
+	var files []string
 
 	vaultArgs := []string{"decrypt"}
 

--- a/cmd/vault_edit.go
+++ b/cmd/vault_edit.go
@@ -26,20 +26,14 @@ func (c *VaultEditCommand) Run(args []string) int {
 		return 1
 	}
 
-	var file string
-
-	switch len(args) {
-	case 0:
-		c.UI.Error("Error: missing FILE argument\n")
-		c.UI.Output(c.Help())
-		return 1
-	case 1:
-		file = args[0]
-	default:
-		c.UI.Error(fmt.Sprintf("Error: too many arguments (expected 1, got %d)\n", len(args)))
+	argCountErr := validateArgumentCount(args, 1, 0)
+	if argCountErr != nil {
+		c.UI.Error(argCountErr.Error())
 		c.UI.Output(c.Help())
 		return 1
 	}
+
+	file := args[0]
 
 	ansibleVault, lookErr := c.CommandExecutor.LookPath("ansible-vault")
 	if lookErr != nil {

--- a/cmd/vault_encrypt.go
+++ b/cmd/vault_encrypt.go
@@ -42,21 +42,16 @@ func (c *VaultEncryptCommand) Run(args []string) int {
 
 	args = c.flags.Args()
 
-	var environment string
-	var files []string
-
-	switch len(args) {
-	case 0:
-		c.UI.Error("Error: missing ENVIRONMENT argument\n")
-		c.UI.Output(c.Help())
-		return 1
-	case 1:
-		environment = args[0]
-	default:
-		c.UI.Error(fmt.Sprintf("Error: too many arguments (expected 1, got %d)\n", len(args)))
+	argCountErr := validateArgumentCount(args, 1, 0)
+	if argCountErr != nil {
+		c.UI.Error(argCountErr.Error())
 		c.UI.Output(c.Help())
 		return 1
 	}
+
+	environment := args[0]
+
+	var files []string
 
 	vaultArgs := []string{"encrypt"}
 

--- a/cmd/vault_view.go
+++ b/cmd/vault_view.go
@@ -41,21 +41,16 @@ func (c *VaultViewCommand) Run(args []string) int {
 
 	args = c.flags.Args()
 
-	var environment string
-	var files []string
-
-	switch len(args) {
-	case 0:
-		c.UI.Error("Error: missing ENVIRONMENT argument\n")
-		c.UI.Output(c.Help())
-		return 1
-	case 1:
-		environment = args[0]
-	default:
-		c.UI.Error(fmt.Sprintf("Error: too many arguments (expected 1, got %d)\n", len(args)))
+	argCountErr := validateArgumentCount(args, 1, 0)
+	if argCountErr != nil {
+		c.UI.Error(argCountErr.Error())
 		c.UI.Output(c.Help())
 		return 1
 	}
+
+	environment := args[0]
+
+	var files []string
 
 	vaultArgs := []string{"view"}
 


### PR DESCRIPTION
- simplify argument count validation logic
- normalize argument count error message

---

Example usage:

```golang
# $ trellis deploy [options] ENVIRONMENT [SITE]

args = c.flags.Args()

argCountErr := validateArgumentCount(args, 1, 1)
if argCountErr != nil {
	c.UI.Error(argCountErr.Error())
	c.UI.Output(c.Help())
	return 1
}

environment := args[0]

siteName := ""
if len(args) == 2 {
	siteName = args[1]
}
```

---

Note: `validateArgumentCount` doesn't support unlimited arguments, i.e: https://github.com/roots/trellis-cli/blob/c043cfd8704fda69dee5387a054ae2be88e1fc1c/cmd/exec.go#L28-L36
