### PR TITLE
Extract `func (t *Trellis) ValidateEnvironment(name string) (err…

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -57,9 +57,9 @@ func (c *DeployCommand) Run(args []string) int {
 		siteName = args[1]
 	}
 
-	_, ok := c.Trellis.Environments[environment]
-	if !ok {
-		c.UI.Error(fmt.Sprintf("Error: %s is not a valid environment", environment))
+	environmentErr := c.Trellis.ValidateEnvironment(environment)
+	if environmentErr != nil {
+		c.UI.Error(environmentErr.Error())
 		return 1
 	}
 

--- a/cmd/dot_env.go
+++ b/cmd/dot_env.go
@@ -33,9 +33,9 @@ func (c *DotEnvCommand) Run(args []string) int {
 		environment = args[0]
 	}
 
-	_, ok := c.Trellis.Environments[environment]
-	if !ok {
-		c.UI.Error(fmt.Sprintf("Error: %s is not a valid environment", environment))
+	environmentErr := c.Trellis.ValidateEnvironment(environment)
+	if environmentErr != nil {
+		c.UI.Error(environmentErr.Error())
 		return 1
 	}
 

--- a/cmd/droplet_create.go
+++ b/cmd/droplet_create.go
@@ -73,6 +73,12 @@ func (c *DropletCreateCommand) Run(args []string) int {
 
 	environment := args[0]
 
+	environmentErr := c.Trellis.ValidateEnvironment(environment)
+	if environmentErr != nil {
+		c.UI.Error(environmentErr.Error())
+		return 1
+	}
+
 	if environment == "development" {
 		c.UI.Error("create command only supports staging/production environments")
 		return 1

--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -54,9 +54,9 @@ func (c *ProvisionCommand) Run(args []string) int {
 
 	environment := args[0]
 
-	_, ok := c.Trellis.Environments[environment]
-	if !ok {
-		c.UI.Error(fmt.Sprintf("Error: %s is not a valid environment", environment))
+	environmentErr := c.Trellis.ValidateEnvironment(environment)
+	if environmentErr != nil {
+		c.UI.Error(environmentErr.Error())
 		return 1
 	}
 

--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -57,9 +57,9 @@ func (c *RollbackCommand) Run(args []string) int {
 		siteName = args[1]
 	}
 
-	_, ok := c.Trellis.Environments[environment]
-	if !ok {
-		c.UI.Error(fmt.Sprintf("Error: %s is not a valid environment", environment))
+	environmentErr := c.Trellis.ValidateEnvironment(environment)
+	if environmentErr != nil {
+		c.UI.Error(environmentErr.Error())
 		return 1
 	}
 

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -39,9 +39,9 @@ func (c *SshCommand) Run(args []string) int {
 
 	var user string
 
-	_, ok := c.Trellis.Environments[environment]
-	if !ok {
-		c.UI.Error(fmt.Sprintf("Error: %s is not a valid environment", environment))
+	environmentErr := c.Trellis.ValidateEnvironment(environment)
+	if environmentErr != nil {
+		c.UI.Error(environmentErr.Error())
 		return 1
 	}
 

--- a/cmd/valet_link.go
+++ b/cmd/valet_link.go
@@ -33,11 +33,13 @@ func (c *ValetLinkCommand) Run(args []string) int {
 		environment = args[0]
 	}
 
-	config, ok := c.Trellis.Environments[environment]
-	if !ok {
-		c.UI.Error(fmt.Sprintf("Error: %s is not a valid environment", environment))
+	environmentErr := c.Trellis.ValidateEnvironment(environment)
+	if environmentErr != nil {
+		c.UI.Error(environmentErr.Error())
 		return 1
 	}
+
+	config, _ := c.Trellis.Environments[environment]
 
 	c.UI.Info(fmt.Sprintf("Linking environment %s...", environment))
 

--- a/cmd/vault_encrypt.go
+++ b/cmd/vault_encrypt.go
@@ -52,6 +52,12 @@ func (c *VaultEncryptCommand) Run(args []string) int {
 
 	environment := args[0]
 
+	environmentErr := c.Trellis.ValidateEnvironment(environment)
+	if environmentErr != nil {
+		c.UI.Error(environmentErr.Error())
+		return 1
+	}
+
 	var files []string
 
 	vaultArgs := []string{"encrypt"}

--- a/cmd/vault_view.go
+++ b/cmd/vault_view.go
@@ -51,6 +51,12 @@ func (c *VaultViewCommand) Run(args []string) int {
 
 	environment := args[0]
 
+	environmentErr := c.Trellis.ValidateEnvironment(environment)
+	if environmentErr != nil {
+		c.UI.Error(environmentErr.Error())
+		return 1
+	}
+
 	var files []string
 
 	vaultArgs := []string{"view"}

--- a/cmd/vault_view_test.go
+++ b/cmd/vault_view_test.go
@@ -56,6 +56,18 @@ func TestVaultViewRunValidations(t *testing.T) {
 
 func TestVaultViewRun(t *testing.T) {
 	ui := cli.NewMockUi()
+	project := &trellis.Project{}
+	trellisProject := trellis.NewTrellis(project)
+
+	defer trellis.TestChdir(t, "../trellis/testdata/trellis")()
+
+	if err := trellisProject.LoadProject(); err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	execCommand = mockExecCommand
+	defer func() { execCommand = exec.Command }()
+
 	mockProject := &MockProject{true}
 	trellis := trellis.NewTrellis(mockProject)
 	vaultViewCommand := NewVaultViewCommand(ui, trellis)

--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -2,6 +2,7 @@ package trellis
 
 import (
 	"errors"
+	"fmt"
 	"gopkg.in/ini.v1"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
@@ -103,6 +104,15 @@ func (t *Trellis) EnvironmentNames() []string {
 	sort.Strings(names)
 
 	return names
+}
+
+func (t *Trellis) ValidateEnvironment(name string) (err error) {
+	_, ok := t.Environments[name]
+	if ok {
+		return nil
+	}
+
+	return fmt.Errorf("Error: %s is not a valid environment, valid options are %s", name, t.EnvironmentNames())
 }
 
 func (t *Trellis) SiteNamesFromEnvironment(environment string) []string {


### PR DESCRIPTION
- Extract `func (t *Trellis) ValidateEnvironment(name string) (err error)
- Normalize error message
- Add environment validation to `VaultEncryptCommand` & `VaultViewCommand` & `DropletCreateCommand`