### PR TITLE
Extract `func (t *Trellis) FindSiteNameFromEnvironment(environment string, siteNameArg string) (string, error) {`

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -51,35 +51,17 @@ func (c *DeployCommand) Run(args []string) int {
 	}
 
 	environment := args[0]
-
-	siteName := ""
-	if len(args) == 2 {
-		siteName = args[1]
-	}
-
 	environmentErr := c.Trellis.ValidateEnvironment(environment)
 	if environmentErr != nil {
 		c.UI.Error(environmentErr.Error())
 		return 1
 	}
 
-	if siteName == "" {
-		sites := c.Trellis.SiteNamesFromEnvironment(environment)
-
-		if len(sites) > 1 {
-			c.UI.Error("Error: missing SITE argument\n")
-			c.UI.Output(c.Help())
-			return 1
-		}
-
-		siteName = sites[0]
-	} else {
-		site := c.Trellis.SiteFromEnvironmentAndName(environment, siteName)
-
-		if site == nil {
-			c.UI.Error(fmt.Sprintf("Error: %s is not a valid site", siteName))
-			return 1
-		}
+	siteNameArg := c.flags.Arg(1)
+	siteName, siteNameErr := c.Trellis.FindSiteNameFromEnvironment(environment, siteNameArg)
+	if siteNameErr != nil {
+		c.UI.Error(siteNameErr.Error())
+		return 1
 	}
 
 	vars := []string{

--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -51,35 +51,17 @@ func (c *RollbackCommand) Run(args []string) int {
 	}
 
 	environment := args[0]
-
-	siteName := ""
-	if len(args) == 2 {
-		siteName = args[1]
-	}
-
 	environmentErr := c.Trellis.ValidateEnvironment(environment)
 	if environmentErr != nil {
 		c.UI.Error(environmentErr.Error())
 		return 1
 	}
 
-	if siteName == "" {
-		sites := c.Trellis.SiteNamesFromEnvironment(environment)
-
-		if len(sites) > 1 {
-			c.UI.Error("Error: missing SITE argument\n")
-			c.UI.Output(c.Help())
-			return 1
-		}
-
-		siteName = sites[0]
-	} else {
-		site := c.Trellis.SiteFromEnvironmentAndName(environment, siteName)
-
-		if site == nil {
-			c.UI.Error(fmt.Sprintf("Error: %s is not a valid site", siteName))
-			return 1
-		}
+	siteNameArg := c.flags.Arg(1)
+	siteName, siteNameErr := c.Trellis.FindSiteNameFromEnvironment(environment, siteNameArg)
+	if siteNameErr != nil {
+		c.UI.Error(siteNameErr.Error())
+		return 1
 	}
 
 	extraVars := fmt.Sprintf("env=%s site=%s", environment, siteName)

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -31,34 +31,25 @@ func (c *SshCommand) Run(args []string) int {
 	}
 
 	environment := args[0]
-
-	siteName := ""
-	if len(args) == 2 {
-		siteName = args[1]
-	}
-
-	var user string
-
 	environmentErr := c.Trellis.ValidateEnvironment(environment)
 	if environmentErr != nil {
 		c.UI.Error(environmentErr.Error())
 		return 1
 	}
 
-	if siteName == "" {
-		sites := c.Trellis.SiteNamesFromEnvironment(environment)
-		siteName = sites[0]
-	} else {
-		site := c.Trellis.SiteFromEnvironmentAndName(environment, siteName)
-
-		if site == nil {
-			c.UI.Error(fmt.Sprintf("Error: %s is not a valid site", siteName))
-			return 1
-		}
+	siteNameArg := ""
+	if len(args) == 2 {
+		siteNameArg = args[1]
+	}
+	siteName, siteNameErr := c.Trellis.FindSiteNameFromEnvironment(environment, siteNameArg)
+	if siteNameErr != nil {
+		c.UI.Error(siteNameErr.Error())
+		return 1
 	}
 
 	host := c.Trellis.SiteFromEnvironmentAndName(environment, siteName).MainHost()
 
+	var user string
 	if environment == "development" {
 		user = "vagrant"
 	} else {

--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -129,6 +129,35 @@ func (t *Trellis) SiteNamesFromEnvironment(environment string) []string {
 	return names
 }
 
+func (t *Trellis) FindSiteNameFromEnvironment(environment string, siteNameArg string) (string, error) {
+	if siteNameArg == "" {
+		return t.getDefaultSiteNameFromEnvironment(environment)
+	}
+
+	siteNames := t.SiteNamesFromEnvironment(environment)
+	for _, siteName := range siteNames {
+		if siteName == siteNameArg {
+			return siteName, nil
+		}
+	}
+
+	return "", fmt.Errorf("Error: %s is not a valid site. Valid options are %s", siteNameArg, siteNames)
+}
+
+func (t *Trellis) getDefaultSiteNameFromEnvironment(environment string) (siteName string, err error) {
+	sites := t.SiteNamesFromEnvironment(environment)
+
+	siteCount := len(sites)
+	switch {
+	case siteCount == 0:
+		return "", fmt.Errorf("Error: No sites found in %s", environment)
+	case siteCount > 1:
+		return "", fmt.Errorf("Error: Multiple sites found in %s. Please specific a site. Valid options are %s", environment, sites)
+	}
+
+	return sites[0], nil
+}
+
 func (t *Trellis) SiteFromEnvironmentAndName(environment string, name string) *Site {
 	return t.Environments[environment].WordPressSites[name]
 }

--- a/trellis/trellis_test.go
+++ b/trellis/trellis_test.go
@@ -3,8 +3,8 @@ package trellis
 import (
 	"fmt"
 	"io/ioutil"
-	"testing"
 	"os"
+	"testing"
 )
 
 func TestCreateConfigDir(t *testing.T) {
@@ -185,5 +185,28 @@ func TestFindSiteNameFromEnvironmentInvalid(t *testing.T) {
 
 	if actual != "" {
 		t.Errorf("expected empty string got %s", actual)
+	}
+}
+
+func TestSiteFromEnvironmentAndName(t *testing.T) {
+	expected := &Site{}
+
+	environments := make(map[string]*Config)
+	environments["a"] = &Config{
+		WordPressSites: make(map[string]*Site),
+	}
+
+	environments["a"].WordPressSites["a1"] = &Site{}
+	environments["a"].WordPressSites["a2"] = expected
+	environments["a"].WordPressSites["a3"] = &Site{}
+
+	trellis := Trellis{
+		Environments: environments,
+	}
+
+	actual := trellis.SiteFromEnvironmentAndName("a", "a2")
+
+	if actual != expected {
+		t.Error("expected site not returned")
 	}
 }

--- a/trellis/trellis_test.go
+++ b/trellis/trellis_test.go
@@ -93,3 +93,97 @@ func TestSiteNamesFromEnvironment(t *testing.T) {
 		t.Errorf("expected %s got %s", expected, actual)
 	}
 }
+
+func TestFindSiteNameFromEnvironmentDefault(t *testing.T) {
+	expected := "a1"
+
+	environments := make(map[string]*Config)
+	environments["a"] = &Config{
+		WordPressSites: make(map[string]*Site),
+	}
+
+	environments["a"].WordPressSites[expected] = &Site{}
+
+	trellis := Trellis{
+		Environments: environments,
+	}
+
+	actual, actualErr := trellis.FindSiteNameFromEnvironment("a", "")
+
+	if actual != expected {
+		t.Errorf("expected %s got %s", expected, actual)
+	}
+
+	if actualErr != nil {
+		t.Errorf("expected nil got %s", actual)
+	}
+}
+
+func TestFindSiteNameFromEnvironmentDefaultError(t *testing.T) {
+	environments := make(map[string]*Config)
+	environments["a"] = &Config{
+		WordPressSites: make(map[string]*Site),
+	}
+
+	trellis := Trellis{
+		Environments: environments,
+	}
+
+	actual, actualErr := trellis.FindSiteNameFromEnvironment("a", "")
+
+	if actualErr == nil {
+		t.Error("expected error got nil")
+	}
+
+	if actual != "" {
+		t.Errorf("expected empty string got %s", actual)
+	}
+}
+
+func TestFindSiteNameFromEnvironment(t *testing.T) {
+	expected := "a1"
+
+	environments := make(map[string]*Config)
+	environments["a"] = &Config{
+		WordPressSites: make(map[string]*Site),
+	}
+
+	environments["a"].WordPressSites[expected] = &Site{}
+
+	trellis := Trellis{
+		Environments: environments,
+	}
+
+	actual, actualErr := trellis.FindSiteNameFromEnvironment("a", expected)
+
+	if actual != expected {
+		t.Errorf("expected %s got %s", expected, actual)
+	}
+
+	if actualErr != nil {
+		t.Errorf("expected nil got %s", actual)
+	}
+}
+
+func TestFindSiteNameFromEnvironmentInvalid(t *testing.T) {
+	environments := make(map[string]*Config)
+	environments["a"] = &Config{
+		WordPressSites: make(map[string]*Site),
+	}
+
+	environments["a"].WordPressSites["a1"] = &Site{}
+
+	trellis := Trellis{
+		Environments: environments,
+	}
+
+	actual, actualErr := trellis.FindSiteNameFromEnvironment("a", "not-exist")
+
+	if actualErr == nil {
+		t.Error("expected error got nil")
+	}
+
+	if actual != "" {
+		t.Errorf("expected empty string got %s", actual)
+	}
+}

--- a/trellis/trellis_test.go
+++ b/trellis/trellis_test.go
@@ -26,6 +26,8 @@ func TestCreateConfigDir(t *testing.T) {
 
 func TestEnvironmentNames(t *testing.T) {
 	environments := make(map[string]*Config)
+
+	// Intentionally not in alphabetical order.
 	environments["b"] = &Config{}
 	environments["z"] = &Config{}
 	environments["a"] = &Config{}

--- a/trellis/trellis_test.go
+++ b/trellis/trellis_test.go
@@ -42,3 +42,31 @@ func TestEnvironmentNames(t *testing.T) {
 		t.Errorf("expected %s got %s", expected, actual)
 	}
 }
+
+func TestValidateEnvironment(t *testing.T) {
+	environments := make(map[string]*Config)
+	environments["a"] = &Config{}
+
+	trellis := Trellis{
+		Environments: environments,
+	}
+
+	actual := trellis.ValidateEnvironment("a")
+	if actual != nil {
+		t.Errorf("expected nil got %s", actual)
+	}
+}
+
+func TestValidateEnvironmentInvalid(t *testing.T) {
+	environments := make(map[string]*Config)
+	environments["a"] = &Config{}
+
+	trellis := Trellis{
+		Environments: environments,
+	}
+
+	actual := trellis.ValidateEnvironment("x")
+	if actual == nil {
+		t.Error("expected error got nil", actual)
+	}
+}

--- a/trellis/trellis_test.go
+++ b/trellis/trellis_test.go
@@ -70,3 +70,26 @@ func TestValidateEnvironmentInvalid(t *testing.T) {
 		t.Error("expected error got nil", actual)
 	}
 }
+
+func TestSiteNamesFromEnvironment(t *testing.T) {
+	environments := make(map[string]*Config)
+	environments["a"] = &Config{
+		WordPressSites: make(map[string]*Site),
+	}
+
+	environments["a"].WordPressSites["a1"] = &Site{}
+	environments["a"].WordPressSites["a2"] = &Site{}
+	environments["a"].WordPressSites["a3"] = &Site{}
+
+	trellis := Trellis{
+		Environments: environments,
+	}
+
+	actual := trellis.SiteNamesFromEnvironment("a")
+
+	expected := []string{"a1", "a2", "a3"}
+
+	if fmt.Sprintf("%s", actual) != fmt.Sprintf("%s", expected) {
+		t.Errorf("expected %s got %s", expected, actual)
+	}
+}

--- a/trellis/trellis_test.go
+++ b/trellis/trellis_test.go
@@ -140,6 +140,30 @@ func TestFindSiteNameFromEnvironmentDefaultError(t *testing.T) {
 	}
 }
 
+func TestFindSiteNameFromEnvironmentDefaultErrorMultiple(t *testing.T) {
+	environments := make(map[string]*Config)
+	environments["a"] = &Config{
+		WordPressSites: make(map[string]*Site),
+	}
+
+	environments["a"].WordPressSites["a1"] = &Site{}
+	environments["a"].WordPressSites["a2"] = &Site{}
+
+	trellis := Trellis{
+		Environments: environments,
+	}
+
+	actual, actualErr := trellis.FindSiteNameFromEnvironment("a", "")
+
+	if actualErr == nil {
+		t.Error("expected error got nil")
+	}
+
+	if actual != "" {
+		t.Errorf("expected empty string got %s", actual)
+	}
+}
+
 func TestFindSiteNameFromEnvironment(t *testing.T) {
 	expected := "a1"
 

--- a/trellis/trellis_test.go
+++ b/trellis/trellis_test.go
@@ -1,6 +1,7 @@
 package trellis
 
 import (
+	"fmt"
 	"io/ioutil"
 	"testing"
 	"os"
@@ -20,5 +21,24 @@ func TestCreateConfigDir(t *testing.T) {
 	_, err := os.Stat(configPath)
 	if err != nil {
 		t.Error("expected config directory to be created")
+	}
+}
+
+func TestEnvironmentNames(t *testing.T) {
+	environments := make(map[string]*Config)
+	environments["b"] = &Config{}
+	environments["z"] = &Config{}
+	environments["a"] = &Config{}
+
+	trellis := Trellis{
+		Environments: environments,
+	}
+
+	actual := trellis.EnvironmentNames()
+
+	expected := []string{"a", "b", "z"}
+
+	if fmt.Sprintf("%s", actual) != fmt.Sprintf("%s", expected) {
+		t.Errorf("expected %s got %s", expected, actual)
 	}
 }

--- a/trellis/trellis_test.go
+++ b/trellis/trellis_test.go
@@ -1,0 +1,24 @@
+package trellis
+
+import (
+	"io/ioutil"
+	"testing"
+	"os"
+)
+
+func TestCreateConfigDir(t *testing.T) {
+	dir, _ := ioutil.TempDir("", "")
+	defer os.RemoveAll(dir)
+	configPath := dir + "/testing-trellis-create-config-dir"
+
+	trellis := Trellis{
+		ConfigPath: configPath,
+	}
+
+	trellis.CreateConfigDir()
+
+	_, err := os.Stat(configPath)
+	if err != nil {
+		t.Error("expected config directory to be created")
+	}
+}


### PR DESCRIPTION
- Extract `func (t *Trellis) FindSiteNameFromEnvironment(environment string, siteNameArg string) (string, error) {`
- Normalize error message