### PR TITLE
Fix deploy args

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -73,7 +73,7 @@ func (c *DeployCommand) Run(args []string) int {
 		vars = append(vars, c.extraVars)
 	}
 
-	extraVars := fmt.Sprintf("\"%s\"", strings.Join(vars, " "))
+	extraVars := strings.Join(vars, " ")
 
 	playbookArgs := []string{"deploy.yml", "-e", extraVars}
 	deploy := execCommand("ansible-playbook", playbookArgs...)

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -102,19 +102,19 @@ func TestDeployRun(t *testing.T) {
 		{
 			"default",
 			[]string{"development", "example.com"},
-			`ansible-playbook deploy.yml -e "env=development site=example.com"`,
+			"ansible-playbook deploy.yml -e env=development site=example.com",
 			0,
 		},
 		{
 			"site_not_needed_in_defaut_case",
 			[]string{"development"},
-			`ansible-playbook deploy.yml -e "env=development site=example.com"`,
+			"ansible-playbook deploy.yml -e env=development site=example.com",
 			0,
 		},
 		{
 			"with_extra_vars",
 			[]string{"-extra-vars", "k=v foo=bar", "development"},
-			`ansible-playbook deploy.yml -e "env=development site=example.com k=v foo=bar"`,
+			"ansible-playbook deploy.yml -e env=development site=example.com k=v foo=bar",
 			0,
 		},
 	}


### PR DESCRIPTION
These vars aren't being recognized by Ansible due to the quoting.

Looking at the existing deploy.sh script and they aren't quoted in there.

@TangRufus it makes sense for me to fix this first in master since it shouldn't be part of your playbook PR.