### PR TITLE
Automatically install Galaxy roles with -f

### DIFF
--- a/cmd/galaxy_install_test.go
+++ b/cmd/galaxy_install_test.go
@@ -93,7 +93,7 @@ func TestGalaxyInstallRun(t *testing.T) {
 			"default",
 			[]string{},
 			[]string{"galaxy.yml", "requirements.yml"},
-			"ansible-galaxy install -r galaxy.yml\nWarning: multiple role files found. Defaulting to galaxy.yml",
+			"ansible-galaxy install -r galaxy.yml\n\nWarning: multiple role files found. Defaulting to galaxy.yml",
 			0,
 		},
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,15 +3,28 @@ package cmd
 import (
 	"fmt"
 	"github.com/mitchellh/cli"
-	"os"
 	"os/exec"
 	"strings"
 )
 
 var execCommand = exec.Command
 
+type UiErrorWriter struct {
+	Ui cli.Ui
+}
+
+func (w *UiErrorWriter) Write(p []byte) (n int, err error) {
+	n = len(p)
+	if n > 0 && p[n-1] == '\n' {
+		p = p[:n-1]
+	}
+
+	w.Ui.Error(string(p))
+	return n, nil
+}
+
 func logCmd(cmd *exec.Cmd, ui cli.Ui, output bool) {
-	cmd.Stderr = os.Stderr
+	cmd.Stderr = &UiErrorWriter{ui}
 
 	if output {
 		cmd.Stdout = &cli.UiWriter{ui}


### PR DESCRIPTION
Closes #95 

This will automatically detect roles that are already installed but a different version than specified in the roles file (`galaxy.yml`) and install them for you.

This solves an annoying problem with `ansible-galaxy` because the easier  solution is to run `install --force` but that re-installs *everything* and is slower.