### PR TITLE
Automatically run galaxy install during provision

### DIFF
--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -59,6 +59,9 @@ func (c *ProvisionCommand) Run(args []string) int {
 		return 1
 	}
 
+	galaxyInstallCommand := &GalaxyInstallCommand{c.UI, c.Trellis}
+	galaxyInstallCommand.Run([]string{})
+
 	c.playbook.SetRoot(c.Trellis.Path)
 
 	vars := "env=" + environment


### PR DESCRIPTION
I can't really think of a downside to this considering:

1. the galaxy roles are required to provision
2. subsequent `install` commands are quite fast if roles are already installed (plus provisioning is slow)

This removes the need to manually remember to run `galaxy install` or being confused when provision fails due to a missing role.