### PR TITLE
Refactor tests: Do not use `MockProject` whenever possible

### DIFF
--- a/cmd/galaxy_install_test.go
+++ b/cmd/galaxy_install_test.go
@@ -100,8 +100,8 @@ func TestGalaxyInstallRun(t *testing.T) {
 
 	for _, tc := range cases {
 		ui := cli.NewMockUi()
-		mockProject := &MockProject{true}
-		trellis := trellis.NewTrellis(mockProject)
+		project := &trellis.Project{}
+		trellis := trellis.NewTrellis(project)
 		galaxyInstallCommand := GalaxyInstallCommand{ui, trellis}
 
 		for _, file := range tc.roleFiles {

--- a/cmd/ssh_test.go
+++ b/cmd/ssh_test.go
@@ -112,8 +112,8 @@ func TestSshRun(t *testing.T) {
 
 	for _, tc := range cases {
 		mockCmd := &MockCommand{}
-		mockProject := &MockProject{true}
-		trellis := trellis.NewTrellis(mockProject)
+		project := &trellis.Project{}
+		trellis := trellis.NewTrellis(project)
 		sshCommand := &SshCommand{ui, trellis, &MockCommandExecutor{mockCmd}}
 
 		code := sshCommand.Run(tc.args)

--- a/cmd/vault_edit_test.go
+++ b/cmd/vault_edit_test.go
@@ -76,8 +76,8 @@ func TestVaultEditRun(t *testing.T) {
 
 	for _, tc := range cases {
 		mockCmd := &MockCommand{}
-		mockProject := &MockProject{true}
-		trellis := trellis.NewTrellis(mockProject)
+		project := &trellis.Project{}
+		trellis := trellis.NewTrellis(project)
 		vaultEditCommand := NewVaultEditCommand(ui, trellis, &MockCommandExecutor{mockCmd})
 
 		code := vaultEditCommand.Run(tc.args)


### PR DESCRIPTION
See: https://github.com/roots/trellis-cli/pull/100#discussion_r373815271