### PR TITLE
Add `SSLFetchCommand`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Supported commands so far:
 | `provision` | Provisions the specified environment |
 | `rollback` | Rollsback the last deploy of the site on the specified environment |
 | `ssh` | Connects to host via SSH |
+| `ssl` | Commands for SSL certificates management |
 | `up` | Starts and provisions the Vagrant environment by running `vagrant up` |
 | `valet` | Commands for Laravel Valet |
 | `vault` | Commands for Ansible Vault |

--- a/cmd/ssl_fetch.go
+++ b/cmd/ssl_fetch.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/fatih/color"
+	"github.com/mitchellh/cli"
+	"strings"
+	"time"
+	"trellis-cli/trellis"
+)
+
+type SSLFetchCommand struct {
+	UI       cli.Ui
+	Trellis  *trellis.Trellis
+	playbook PlaybookRunner
+}
+
+const sslFetchYmlContent = `
+---
+- name: Test Connection and Determine Remote User
+  hosts: web:&{{ env }}
+  gather_facts: false
+  roles:
+    - { role: connection, tags: [connection, always] }
+
+- name: "Trellis CLI: Pull SSL certificates"
+  hosts: web:&{{ env }}
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Conditionally 'nginx_path' variable from nginx role
+      include_vars:
+        file: roles/nginx/defaults/main.yml
+      when: nginx_path is not defined
+
+    - name: Fail if couldn't determine 'nginx_path' variable
+      fail:
+        msg: Failed to load 'nginx_path' variable
+      when: nginx_path is not defined
+
+    - name: Find files under SSL directory
+      find:
+        paths: "{{ nginx_path }}/ssl/"
+        recurse: yes
+        excludes:
+          - no_default.cert
+          - no_default.key
+          - dhparams.pem
+      register: find_result
+
+    - name: Fetch SSL certificates
+      fetch:
+        src: "{{ item.path }}"
+        dest: "{{ dest }}"
+      with_items: "{{ find_result.files }}"
+`
+
+func NewSSLFetchCommand(ui cli.Ui, trellis *trellis.Trellis) *SSLFetchCommand {
+	playbook := &AdHocPlaybook{
+		files: map[string]string{
+			"ssl-fetch.yml": sslFetchYmlContent,
+		},
+		Playbook: Playbook{
+			ui: ui,
+		},
+	}
+
+	return &SSLFetchCommand{UI: ui, Trellis: trellis, playbook: playbook}
+}
+
+func (c *SSLFetchCommand) Run(args []string) int {
+	if err := c.Trellis.LoadProject(); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	commandArgumentValidator := &CommandArgumentValidator{required: 1, optional: 0}
+	commandArgumentErr := commandArgumentValidator.validate(args)
+	if commandArgumentErr != nil {
+		c.UI.Error(commandArgumentErr.Error())
+		c.UI.Output(c.Help())
+		return 1
+	}
+
+	environment := args[0]
+	environmentErr := c.Trellis.ValidateEnvironment(environment)
+	if environmentErr != nil {
+		c.UI.Error(environmentErr.Error())
+		return 1
+	}
+
+	now := time.Now()
+	dest := c.Trellis.Path + "/trellis-cli/ssl/fetch-" + now.Format("20060102150405")
+
+	c.playbook.SetRoot(c.Trellis.Path)
+
+	if err := c.playbook.Run("ssl-fetch.yml", []string{"-e", "env=" + environment, "-e", "dest=" + dest}); err != nil {
+		c.UI.Error(fmt.Sprintf("Error running ansible-playbook: %s", err))
+		return 1
+	}
+
+	c.UI.Info(color.GreenString(fmt.Sprintf("✓ SSL certificates fetched into %s\n", dest)))
+	return 0
+}
+
+func (c *SSLFetchCommand) Synopsis() string {
+	return "Fetch ssl certificates to local system"
+}
+
+func (c *SSLFetchCommand) Help() string {
+	helpText := `
+Usage: trellis ssl fetch [options] ENVIRONMENT
+
+Fetch ssl certificates to local system
+
+Options:
+  -h, --help  show this help
+`
+
+	return strings.TrimSpace(helpText)
+}

--- a/cmd/ssl_fetch_test.go
+++ b/cmd/ssl_fetch_test.go
@@ -1,0 +1,145 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/cli"
+	"trellis-cli/trellis"
+)
+
+func TestSSLFetchArgumentValidations(t *testing.T) {
+	ui := cli.NewMockUi()
+
+	cases := []struct {
+		name            string
+		projectDetected bool
+		args            []string
+		out             string
+		code            int
+	}{
+		{
+			"no_project",
+			false,
+			nil,
+			"No Trellis project detected",
+			1,
+		},
+		{
+			"too_many_args",
+			true,
+			[]string{"foo", "bar"},
+			"Error: too many arguments",
+			1,
+		},
+	}
+
+	for _, tc := range cases {
+		mockProject := &MockProject{tc.projectDetected}
+		trellis := trellis.NewTrellis(mockProject)
+
+		sslFetchCommand := SSLFetchCommand{UI: ui, Trellis: trellis, playbook: &MockPlaybook{ui: ui}}
+
+		code := sslFetchCommand.Run(tc.args)
+
+		if code != tc.code {
+			t.Errorf("expected code %d to be %d", code, tc.code)
+		}
+
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+
+		if !strings.Contains(combined, tc.out) {
+			t.Errorf("expected output %q to contain %q", combined, tc.out)
+		}
+	}
+}
+
+func TestSSLFetchInvalidEnvironmentArgument(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
+	ui := cli.NewMockUi()
+
+	cases := []struct {
+		name            string
+		projectDetected bool
+		args            []string
+		out             string
+		code            int
+	}{
+		{
+			"invalid_env",
+			true,
+			[]string{"foo"},
+			"Error: foo is not a valid environment",
+			1,
+		},
+	}
+
+	for _, tc := range cases {
+		mockProject := &MockProject{tc.projectDetected}
+		trellis := trellis.NewTrellis(mockProject)
+
+		sslFetchCommand := SSLFetchCommand{UI: ui, Trellis: trellis, playbook: &MockPlaybook{ui: ui}}
+
+		code := sslFetchCommand.Run(tc.args)
+
+		if code != tc.code {
+			t.Errorf("expected code %d to be %d", code, tc.code)
+		}
+
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+
+		if !strings.Contains(combined, tc.out) {
+			t.Errorf("expected output %q to contain %q", combined, tc.out)
+		}
+	}
+}
+
+func TestSSLFetchRun(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
+	ui := cli.NewMockUi()
+	project := &trellis.Project{}
+	trellis := trellis.NewTrellis(project)
+	mockPlaybook := &MockPlaybook{ui: ui}
+	sslFetchCommand := &SSLFetchCommand{UI: ui, Trellis: trellis, playbook: mockPlaybook}
+
+	cases := []struct {
+		args    []string
+		commandCount int
+		command string
+		out     string
+		code    int
+	}{
+		{
+			[]string{"production"},
+			1,
+			"ansible-playbook ssl-fetch.yml -e env=production -e dest=",
+			"SSL certificates fetched into",
+			0,
+		},
+	}
+
+	for _, tc := range cases {
+		code := sslFetchCommand.Run(tc.args)
+
+		combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+		commands := mockPlaybook.GetCommands()
+
+		commandCount := len(commands)
+		if commandCount != tc.commandCount {
+			t.Errorf("expected playbook to be ran excatly %d time(s), but ran %d time(s)", tc.commandCount, commandCount)
+		}
+
+		command := commands[0]
+		if !strings.Contains(command, tc.command) {
+			t.Errorf("Expected command %s to contain %s", command, tc.command)
+		}
+
+		if !strings.Contains(combined, tc.out) {
+			t.Errorf("expected output %q to contain %q", combined, tc.out)
+		}
+
+		if code != tc.code {
+			t.Errorf("expected code %d to be %d", code, tc.code)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -95,6 +95,9 @@ func main() {
 				SynopsisText: "Commands for SSL certificates management",
 			}, nil
 		},
+		"ssl fetch": func() (cli.Command, error) {
+			return cmd.NewSSLFetchCommand(ui, trellis), nil
+		},
 		"up": func() (cli.Command, error) {
 			return cmd.NewUpCommand(ui, trellis), nil
 		},

--- a/main.go
+++ b/main.go
@@ -89,6 +89,12 @@ func main() {
 		"ssh": func() (cli.Command, error) {
 			return &cmd.SshCommand{ui, trellis, &cmd.SyscallCommandExecutor{}}, nil
 		},
+		"ssl": func() (cli.Command, error) {
+			return &cmd.NamespaceCommand{
+				HelpText:     "Usage: trellis ssl <subcommand> [<args>]",
+				SynopsisText: "Commands for SSL certificates management",
+			}, nil
+		},
 		"up": func() (cli.Command, error) {
 			return cmd.NewUpCommand(ui, trellis), nil
 		},


### PR DESCRIPTION
Why not use ansible synchronize module?

Because it only supports passwordless sudo.

Why use ansible find module?

Because the fetch module doesn't support fetching directories recursively.

Related: https://github.com/roots/trellis-cli/issues/10