### PR TITLE
Make autocompletion lazier

### DIFF
--- a/trellis/complete.go
+++ b/trellis/complete.go
@@ -5,23 +5,19 @@ import (
 )
 
 func (t *Trellis) AutocompleteSite() complete.Predictor {
-	if err := t.LoadProject(); err != nil {
-		return complete.PredictNothing
-	}
-
 	return t.PredictSite()
 }
 
 func (t *Trellis) AutocompleteEnvironment() complete.Predictor {
-	if err := t.LoadProject(); err != nil {
-		return complete.PredictNothing
-	}
-
 	return t.PredictEnvironment()
 }
 
 func (t *Trellis) PredictSite() complete.PredictFunc {
 	return func(args complete.Args) []string {
+		if err := t.LoadProject(); err != nil {
+			return []string{}
+		}
+
 		switch len(args.Completed) {
 		case 1:
 			return t.EnvironmentNames()
@@ -35,6 +31,10 @@ func (t *Trellis) PredictSite() complete.PredictFunc {
 
 func (t *Trellis) PredictEnvironment() complete.PredictFunc {
 	return func(args complete.Args) []string {
+		if err := t.LoadProject(); err != nil {
+			return []string{}
+		}
+
 		switch len(args.Completed) {
 		case 1:
 			return t.EnvironmentNames()


### PR DESCRIPTION
These autocomplete functions are called *every* time the binary is run which was calling `LoadProject` in contexts we don't actually care if a project exists or not (like running `trellis help`, or any command which is project independent).

The only situations we actually want a project loaded is when we're autocompleting for the commands which is what will happen now since the checks are *within* the `PredictFunc`.

https://github.com/roots/trellis-cli/pull/65 was my previous "fix" for this but all that did was speed up successive **successful** look ups.