### PR TITLE
Run galaxy install on new project

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -151,6 +151,9 @@ func (c *NewCommand) Run(args []string) int {
 		c.UI.Error(fmt.Sprintf("Error adding vault_password_file setting to ansible.cfg: %s", err))
 	}
 
+	galaxyInstallCommand := &GalaxyInstallCommand{c.UI, c.trellis}
+	galaxyInstallCommand.Run([]string{})
+
 	fmt.Printf("\n%s project created with versions:\n", color.GreenString(c.name))
 	fmt.Printf("  Trellis v%s\n", trellisVersion)
 	fmt.Printf("  Bedrock v%s\n", bedrockVersion)


### PR DESCRIPTION
Also changes the `up` command to default to skipping galaxy install.
This changes the flag from `--no-galaxy` to `--with-galaxy`.

Since trellis-cli improves `galaxy install` and auto-runs on `provision`
and `new`, it makes sense to avoid the crappy `ansible-galaxy install`
run by Vagrant by default.