### PR TITLE
fix(new): Fix double `v` on Trellis version

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -155,7 +155,7 @@ func (c *NewCommand) Run(args []string) int {
 	galaxyInstallCommand.Run([]string{})
 
 	fmt.Printf("\n%s project created with versions:\n", color.GreenString(c.name))
-	fmt.Printf("  Trellis v%s\n", trellisVersion)
+	fmt.Printf("  Trellis %s\n", trellisVersion)
 	fmt.Printf("  Bedrock v%s\n", bedrockVersion)
 
 	return 0


### PR DESCRIPTION
Trellis is versioned with `v` on GitHub where as Bedrock is not.

![Screenshot](https://i.imgur.com/LKTkXnk.png)

![Trellis](https://i.imgur.com/VWsXcnf.png)
![Bedrock](https://i.imgur.com/e8Uf68K.png)