### PR TITLE
Improve logCmd output

### DIFF
--- a/cmd/db_opener_sequel_pro_test.go
+++ b/cmd/db_opener_sequel_pro_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/mitchellh/cli"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -30,13 +31,11 @@ func TestOpen(t *testing.T) {
 	actualCombined := ui.OutputWriter.String() + ui.ErrorWriter.String()
 	actualCombined = strings.TrimSpace(actualCombined)
 
-	expectedPrefix := "open"
-	if !strings.HasPrefix(actualCombined, expectedPrefix) {
-		t.Errorf("expected command %q to have prefix %q", actualCombined, expectedPrefix)
-	}
+	pattern := `open .*\.spf`
 
-	expectedSuffix := ".spf"
-	if !strings.HasSuffix(actualCombined, expectedSuffix) {
-		t.Errorf("expected command %q to have suffix %q", actualCombined, expectedSuffix)
+	matched, _ := regexp.MatchString(pattern, actualCombined)
+
+	if !matched {
+		t.Errorf("expected command %q to match %q", actualCombined, pattern)
 	}
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -30,5 +30,5 @@ func logCmd(cmd *exec.Cmd, ui cli.Ui, output bool) {
 		cmd.Stdout = &cli.UiWriter{ui}
 	}
 
-	fmt.Println("Running command =>", strings.Join(cmd.Args, " "))
+	ui.Info(fmt.Sprintf("Running command => %s", strings.Join(cmd.Args, " ")))
 }


### PR DESCRIPTION
This uses the ui.Info instead of fmt.Println for consistency. It also means during tests we won't see the "Running program" lines.