### PR TITLE
Fixes #121 - Fix `up` cmd environment

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"flag"
 	"strings"
+	"os"
 
 	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
@@ -58,8 +59,14 @@ func (c *UpCommand) Run(args []string) int {
 
 	vagrantUp := execCommandWithOutput("vagrant", vagrantArgs, c.UI)
 
+	env := os.Environ()
+	// To allow mockExecCommand injects its environment variables.
+	if vagrantUp.Env != nil {
+		env = vagrantUp.Env
+	}
+
 	if !c.withGalaxy {
-		vagrantUp.Env = append(vagrantUp.Env, "SKIP_GALAXY=true")
+		vagrantUp.Env = append(env, "SKIP_GALAXY=true")
 	}
 
 	err := vagrantUp.Run()


### PR DESCRIPTION
exec.Cmd defaults to the current process's environment which is what we almost always want. But in cases when we need to set a command `Env` we can't just append to its own `Env`. We need to explicitly use `os.Environ()` and append to that.