### PR TITLE
Fix `vault decrypt <env>` command

### DIFF
--- a/cmd/vault_decrypt.go
+++ b/cmd/vault_decrypt.go
@@ -82,7 +82,7 @@ func (c *VaultDecryptCommand) Run(args []string) int {
 		return 0
 	}
 
-	vaultArgs = append(vaultArgs, files...)
+	vaultArgs = append(vaultArgs, filesToDecrypt...)
 
 	vaultDecrypt := execCommandWithOutput("ansible-vault", vaultArgs, c.UI)
 	err := vaultDecrypt.Run()


### PR DESCRIPTION
Fixes #132 which was trying to decrypted non-encrypted files causing it to error and stop.

@TangRufus not 100% sure how to test this properly but the fix is simple away