### PR TITLE
`InitCommand`: Show `pip` stack trace when failed

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"os/exec"
+	"github.com/fatih/color"
 	"strings"
 	"time"
 
@@ -39,10 +39,10 @@ func (c *InitCommand) Run(args []string) int {
 		c.UI.Info("virtualenv not found")
 		s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
 		s.Suffix = " Installing virtualenv..."
-		s.FinalMSG = "✓ virtualenv installed\n"
 		s.Start()
 		c.Trellis.Virtualenv.Install()
 		s.Stop()
+		c.UI.Info(color.GreenString("✓ virtualenv installed"))
 	}
 
 	c.UI.Info(fmt.Sprintf("Creating virtualenv in %s", c.Trellis.Virtualenv.Path))
@@ -53,24 +53,22 @@ func (c *InitCommand) Run(args []string) int {
 		return 1
 	}
 
-	c.UI.Info("✓ Virtualenv created\n")
+	c.UI.Info(color.GreenString("✓ Virtualenv created"))
 
-	pip := exec.Command("pip", "install", "-r", "requirements.txt")
+	pip := CommandExecWithStderrOnly("pip", []string{"install", "-r", "requirements.txt"}, c.UI)
 
 	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
 	s.Suffix = " Installing pip dependencies (pip install -r requirements.txt) ..."
-	s.FinalMSG = "✓ Dependencies installed\n"
 	s.Start()
 
 	err = pip.Run()
+	s.Stop()
 
 	if err != nil {
-		s.Stop()
-		c.UI.Error(fmt.Sprintf("Error installing pip requirements: %s", err))
 		return 1
 	}
 
-	s.Stop()
+	c.UI.Info(color.GreenString("✓ Dependencies installed"))
 
 	return 0
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,6 +37,15 @@ func CommandExecWithOutput(command string, args []string, ui cli.Ui) *exec.Cmd {
 	return cmd
 }
 
+func CommandExecWithStderrOnly(command string, args []string, ui cli.Ui) *exec.Cmd {
+	cmd := exec.Command(command, args...)
+	cmd.Stderr = os.Stderr
+
+	ui.Info(fmt.Sprintf("Running command => %s", strings.Join(cmd.Args, " ")))
+
+	return cmd
+}
+
 func CommandExec(command string, args []string, ui cli.Ui) *exec.Cmd {
 	cmd := exec.Command(command, args...)
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
Goal: To provide more helpful error messages

Before:

```sh-session
$ trellis init
Creating virtualenv in /Users/rufus/Code/typist/trellis/.trellis/virtualenv
✓ Virtualenv created

✓ Dependencies installed
Error installing pip requirements: exit status 1
```

After:

```sh-session
$ trellis init
Creating virtualenv in /Users/rufus/Code/typist/trellis/.trellis/virtualenv
✓ Virtualenv created

✓ Dependencies installed
Error installing pip requirements: exit status 1
Stack trace:
Requirement already satisfied: ansible<3.0,>=2.8.0 in ./.trellis/virtualenv/lib/python3.9/site-packages (from -r requirements.txt (line 1)) (2.10.1)
Requirement already satisfied: passlib in ./.trellis/virtualenv/lib/python3.9/site-packages (from -r requirements.txt (line 2)) (1.7.4)
ERROR: Could not find a version that satisfies the requirement fake-package-to-trigger-error (from -r requirements.txt (line 3)) (from versions: none)
ERROR: No matching distribution found for fake-package-to-trigger-error (from -r requirements.txt (line 3))
WARNING: You are using pip version 20.2.3; however, version 20.2.4 is available.
You should consider upgrading via the '/Users/rufus/Code/typist/trellis/.trellis/virtualenv/bin/python3 -m pip install --upgrade pip' command.
```

To test: Add a fake package in [`requirements.txt`](https://github.com/roots/trellis/blob/2ae8f383af42da9d37bce91531c4175c9d1b6d9f/requirements.txt)

To discuss: 
- Should we do the same on other `exec.Command.Run()`?
- Alternatively, we can use `exec.Command.Output()`
- Is that a way to _correct_ console output coloring like `$ trellis exec pip install -r requirements.txt`?

cc @mariusz-ah