### PR TITLE
Fix #142 - Quote/escape paths in venv hook

### DIFF
--- a/cmd/venv_hook.go
+++ b/cmd/venv_hook.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/mitchellh/cli"
+	"gopkg.in/alessio/shellescape.v1"
 	"trellis-cli/trellis"
 )
 
@@ -21,9 +22,9 @@ func (c *VenvHookCommand) Run(args []string) int {
 	if c.Trellis.ActivateProject() {
 		if !ok {
 			fmt.Fprintf(color.Error, "[trellis] \x1b[1;32mactivated env\x1b[0m\n")
-			c.UI.Output(fmt.Sprintf("export %s=%s", trellis.VenvEnvName, c.Trellis.Virtualenv.Path))
-			c.UI.Output(fmt.Sprintf("export %s=%s", trellis.OldPathEnvName, c.Trellis.Virtualenv.OldPath))
-			c.UI.Output(fmt.Sprintf("export %s=%s:%s", trellis.PathEnvName, c.Trellis.Virtualenv.BinPath, c.Trellis.Virtualenv.OldPath))
+			c.UI.Output(fmt.Sprintf("export %s=%s", trellis.VenvEnvName, shellescape.Quote(c.Trellis.Virtualenv.Path)))
+			c.UI.Output(fmt.Sprintf("export %s=%s", trellis.OldPathEnvName, shellescape.Quote(c.Trellis.Virtualenv.OldPath)))
+			c.UI.Output(fmt.Sprintf("export %s=%s:%s", trellis.PathEnvName, c.Trellis.Virtualenv.BinPath, shellescape.Quote(c.Trellis.Virtualenv.OldPath)))
 		}
 	} else {
 		if ok {
@@ -31,7 +32,7 @@ func (c *VenvHookCommand) Run(args []string) int {
 			path := os.Getenv(trellis.OldPathEnvName)
 			c.UI.Output(fmt.Sprintf("unset %s", trellis.VenvEnvName))
 			c.UI.Output(fmt.Sprintf("unset %s", trellis.OldPathEnvName))
-			c.UI.Output(fmt.Sprintf("export %s=%s", trellis.PathEnvName, path))
+			c.UI.Output(fmt.Sprintf("export %s=%s", trellis.PathEnvName, shellescape.Quote(path)))
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20190130055435-99b60b757ec1
 	golang.org/x/tools v0.0.0-20201028153306-37f0764111ff // indirect
 	gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c // indirect
+	gopkg.in/alessio/shellescape.v1 v1.0.0-20170105083845-52074bc9df61
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/ini.v1 v1.41.0
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,8 @@ google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO50
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c h1:vTxShRUnK60yd8DZU+f95p1zSLj814+5CuEh7NjF2/Y=
 gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c/go.mod h1:3HH7i1SgMqlzxCcBmUHW657sD4Kvv9sC3HpL3YukzwA=
+gopkg.in/alessio/shellescape.v1 v1.0.0-20170105083845-52074bc9df61 h1:8ajkpB4hXVftY5ko905id+dOnmorcS2CHNxxHLLDcFM=
+gopkg.in/alessio/shellescape.v1 v1.0.0-20170105083845-52074bc9df61/go.mod h1:IfMagxm39Ys4ybJrDb7W3Ob8RwxftP0Yy+or/NVz1O8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Without quoting (escaping) paths with spaces (or potentially other special characters) would break the hook script.

cc @jeffbyrnes