### PR TITLE
[Help Wanted] Add plugin system (Look for `trellis-*` in `$PATH`)

### DIFF
--- a/cmd/passthrough.go
+++ b/cmd/passthrough.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+)
+
+type PassthroughCommand struct {
+	Bin  string
+	Name string
+	Args []string
+}
+
+// Taken from https://github.com/kubernetes/kubectl/blob/b155278f1f4a21a0be2d4f6f0037258dee4d1a22/pkg/cmd/cmd.go#L371
+func (c *PassthroughCommand) Run(args []string) int {
+	// Windows does not support exec syscall.
+	if runtime.GOOS == "windows" {
+		cmd := exec.Command(c.Bin, args...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Stdin = os.Stdin
+		cmd.Env = os.Environ()
+		err := cmd.Run()
+		if err == nil {
+			return 0
+		}
+		return 1
+	}
+
+	// invoke cmd binary relaying the environment and args given
+	// append executablePath to cmdArgs, as execve will make first argument the "binary name".
+	if err := syscall.Exec(c.Bin, append([]string{c.Bin}, args...), os.Environ()); err != nil {
+		return 1
+	}
+
+	return 0
+}
+
+func (c *PassthroughCommand) Synopsis() string {
+	return fmt.Sprintf("Third party plugin: Forward command to %s", filepath.Base(c.Bin))
+}
+
+func (c *PassthroughCommand) Help() string {
+	requested := strings.Join(c.Args, " ")
+
+	if strings.HasPrefix(requested, c.Name) {
+		commandParts := len(strings.Split(c.Name, " "))
+		c.Run(c.Args[commandParts:])
+	}
+
+	return ""
+}

--- a/main.go
+++ b/main.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
+	"strconv"
 	"trellis-cli/cmd"
 	"trellis-cli/config"
 	"trellis-cli/github"
+	"trellis-cli/plugin"
 	"trellis-cli/trellis"
 	"trellis-cli/update"
 
@@ -152,6 +155,11 @@ func main() {
 	}
 
 	c.HiddenCommands = []string{"venv", "venv hook"}
+
+	if shouldSkipPlugins, _ := strconv.ParseBool(os.Getenv("TRELLIS_NO_PLUGINS")); !shouldSkipPlugins {
+		pluginPaths := filepath.SplitList(os.Getenv("PATH"))
+		plugin.Register(c, pluginPaths, []string{"trellis"})
+	}
 
 	exitStatus, err := c.Run()
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"github.com/mitchellh/cli"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"trellis-cli/cmd"
+)
+
+func TestIntegrationForceNoPlugin(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	bin := os.Getenv("TEST_BINARY")
+	if bin == "" {
+		t.Error("TEST_BINARY not supplied")
+	}
+	if _, err := os.Stat(bin); os.IsNotExist(err) {
+		t.Error(bin + " not exist")
+	}
+
+	tempDir, err := ioutil.TempDir(os.TempDir(), "test-cmd-plugins")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// cleanup
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			panic(fmt.Errorf("unexpected cleanup error: %v", err))
+		}
+	}()
+
+	file, err := os.Create(filepath.Join(tempDir, "trellis-abc"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err = os.Chmod(file.Name(), 0111); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mockUi := cli.NewMockUi()
+
+	trellisCommand := cmd.CommandExecWithOutput(bin, []string{"--help"}, mockUi)
+	trellisCommand.Env = []string{"PATH=" + tempDir + ":$PATH", "TRELLIS_NO_PLUGINS=true"}
+
+	trellisCommand.Run()
+	output := mockUi.ErrorWriter.String()
+
+	for _, unexpected := range []string{"Available third party plugin commands are", "abc"} {
+		if strings.Contains(output, unexpected) {
+			t.Errorf("unexpected output %q to contain %q", output, unexpected)
+		}
+	}
+}

--- a/plugin/finder.go
+++ b/plugin/finder.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugin
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type finder struct {
+	validPrefixes    []string
+	searchPaths      []string
+	coreRootCommands []string
+}
+
+func (o *finder) find() map[string]string {
+	plugins := make(map[string]string)
+
+	for _, dir := range unique(o.searchPaths) {
+		if len(strings.TrimSpace(dir)) == 0 {
+			continue
+		}
+
+		files, err := ioutil.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+
+		for _, f := range files {
+			if f.IsDir() {
+				continue
+			}
+			if !hasValidPrefix(f.Name(), o.validPrefixes) {
+				continue
+			}
+
+			// Prevent overriding core commands or adding any subcommands under core commands.
+			if isUnderCoreRootCommands(f.Name(), o.coreRootCommands) {
+				continue
+			}
+
+			path := filepath.Join(dir, f.Name())
+			if !isExecutable(path) {
+				continue
+			}
+
+			nameParts := strings.Split(f.Name(), "-")
+			if len(nameParts) > 1 {
+				// the first argument is always one of `validPrefixes` (i.e: "trellis") for a plugin binary
+				nameParts = nameParts[1:]
+			}
+			name := strings.Join(nameParts, " ")
+
+			// TODO: Handle overshadowed plugins, i.e: plugins with the same binary name.
+			plugins[name] = path
+		}
+	}
+
+	return plugins
+}
+
+func isExecutable(fullPath string) bool {
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		return false
+	}
+
+	if runtime.GOOS == "windows" {
+		fileExt := strings.ToLower(filepath.Ext(fullPath))
+
+		switch fileExt {
+		case ".bat", ".cmd", ".com", ".exe", ".ps1":
+			return true
+		}
+		return false
+	}
+
+	if m := info.Mode(); !m.IsDir() && m&0111 != 0 {
+		return true
+	}
+
+	return false
+}
+
+func hasValidPrefix(filepath string, validPrefixes []string) bool {
+	for _, prefix := range validPrefixes {
+		if !strings.HasPrefix(filepath, prefix+"-") {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func isUnderCoreRootCommands(filepath string, coreRootCommands []string) bool {
+	// the first argument is always one of `validPrefixes` (i.e: "trellis") for a plugin binary
+	rootCommand := strings.Split(filepath, "-")[1]
+
+	for _, v := range coreRootCommands {
+		if v == rootCommand {
+			return true
+		}
+	}
+	return false
+}

--- a/plugin/finder_test.go
+++ b/plugin/finder_test.go
@@ -1,0 +1,348 @@
+package plugin
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestFind(t *testing.T) {
+	tempDir, err := ioutil.TempDir(os.TempDir(), "test-cmd-plugins")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// cleanup
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			panic(fmt.Errorf("unexpected cleanup error: %v", err))
+		}
+	}()
+
+	createTempFile := func(name string, mode os.FileMode) (*os.File, error) {
+		file, err := os.Create(filepath.Join(tempDir, name))
+		if err != nil {
+			return nil, err
+		}
+
+		err = os.Chmod(file.Name(), mode)
+		if err != nil {
+			return nil, err
+		}
+
+		return file, nil
+	}
+
+	cases := []struct {
+		name             string
+		validPrefixes    []string
+		searchPaths      []string
+		coreRootCommands []string
+		pluginFileName   string
+		pluginFileMode   os.FileMode
+		out              map[string]string
+	}{
+		{
+			"plugin_root_command",
+			[]string{"trellis"},
+			[]string{tempDir},
+			[]string{"foo", "bar"},
+			"trellis-xxx",
+			0111,
+			map[string]string{
+				"xxx": filepath.Join(tempDir, "trellis-xxx"),
+			},
+		},
+		{
+			"under_core_root_command",
+			[]string{"trellis"},
+			[]string{tempDir},
+			[]string{"foo", "bar"},
+			"trellis-xxx-bar",
+			0111,
+			map[string]string{
+				"xxx bar": filepath.Join(tempDir, "trellis-xxx-bar"),
+			},
+		},
+		{
+			"same_as_core_root_command",
+			[]string{"trellis"},
+			[]string{tempDir},
+			[]string{"foo", "bar"},
+			"trellis-bar",
+			0111,
+			map[string]string{},
+		},
+		{
+			"under_core_root_command",
+			[]string{"trellis"},
+			[]string{tempDir},
+			[]string{"foo", "bar"},
+			"trellis-bar-xxx",
+			0111,
+			map[string]string{},
+		},
+		{
+			"invalid_prefix",
+			[]string{"trellis"},
+			[]string{tempDir},
+			[]string{"foo", "bar"},
+			"not-trellis-xxx",
+			0111,
+			map[string]string{},
+		},
+		{
+			"empty_search_path",
+			[]string{"trellis"},
+			[]string{""},
+			[]string{"foo", "bar"},
+			"trellis-xxx",
+			0111,
+			map[string]string{},
+		},
+		{
+			"empty_and_non_empty_search_paths",
+			[]string{"trellis"},
+			[]string{tempDir, "", " "},
+			[]string{"foo", "bar"},
+			"trellis-xxx",
+			0111,
+			map[string]string{
+				"xxx": filepath.Join(tempDir, "trellis-xxx"),
+			},
+		},
+		{
+			"duplicated_search_paths",
+			[]string{"trellis"},
+			[]string{tempDir, tempDir},
+			[]string{"foo", "bar"},
+			"trellis-xxx",
+			0111,
+			map[string]string{
+				"xxx": filepath.Join(tempDir, "trellis-xxx"),
+			},
+		},
+		{
+			"not_exist_search_path",
+			[]string{"trellis"},
+			[]string{tempDir + "not_exist_search_path"},
+			[]string{"foo", "bar"},
+			"trellis-xxx",
+			0111,
+			map[string]string{},
+		},
+		{
+			"non_executable",
+			[]string{"trellis"},
+			[]string{tempDir},
+			[]string{"foo", "bar"},
+			"trellis-xxx",
+			0666,
+			map[string]string{},
+		},
+	}
+
+	for _, tc := range cases {
+		// cleanup files from previous test case.
+		os.RemoveAll(tempDir)
+		os.MkdirAll(tempDir, 0700)
+
+		if _, err := createTempFile(tc.pluginFileName, tc.pluginFileMode); err != nil {
+			t.Fatalf("unexpected error creating plugin file: %v", err)
+		}
+
+		pluginFinder := finder{
+			validPrefixes:    tc.validPrefixes,
+			searchPaths:      tc.searchPaths,
+			coreRootCommands: tc.coreRootCommands,
+		}
+
+		output := pluginFinder.find()
+
+		if !reflect.DeepEqual(output, tc.out) {
+			t.Errorf("%s: expected output %v to be %v", tc.name, output, tc.out)
+		}
+	}
+}
+
+func TestIsExecutable(t *testing.T) {
+	tempDir, err := ioutil.TempDir(os.TempDir(), "test-cmd-plugins")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// cleanup
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			panic(fmt.Errorf("unexpected cleanup error: %v", err))
+		}
+	}()
+
+	createTempFile := func(mode os.FileMode) (*os.File, error) {
+		file, err := ioutil.TempFile(tempDir, "trellis-")
+		if err != nil {
+			return nil, err
+		}
+
+		err = os.Chmod(file.Name(), mode)
+		if err != nil {
+			return nil, err
+		}
+
+		return file, nil
+	}
+
+	cases := []struct {
+		name string
+		mode os.FileMode
+		out  bool
+	}{
+		{
+			"valid-0100",
+			0100,
+			true,
+		},
+		{
+			"valid-0010",
+			0010,
+			true,
+		},
+		{
+			"valid-0001",
+			0001,
+			true,
+		},
+		{
+			"valid-0111",
+			0111,
+			true,
+		},
+		{
+			"invalid-0666",
+			0666,
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		file, err := createTempFile(tc.mode)
+		if err != nil {
+			t.Fatalf("unexpected error creating plugin file: %v", err)
+		}
+
+		output := isExecutable(file.Name())
+
+		if output != tc.out {
+			t.Errorf("%s: expected output %t to be %t", tc.name, output, tc.out)
+		}
+	}
+}
+
+func TestHasValidPrefix(t *testing.T) {
+	cases := []struct {
+		name          string
+		filepath      string
+		validPrefixes []string
+		out           bool
+	}{
+		{
+			"valid_root_command",
+			"trellis-xxx",
+			[]string{"trellis"},
+			true,
+		},
+		{
+			"valid_subcommand",
+			"trellis-xxx-yyy",
+			[]string{"trellis"},
+			true,
+		},
+		{
+			"invalid_prefix",
+			"xxx-yyy",
+			[]string{"trellis"},
+			false,
+		},
+		{
+			"prefix_without_hyphen",
+			"trellisxxx",
+			[]string{"trellis"},
+			false,
+		},
+		{
+			"prefix_only",
+			"trellis",
+			[]string{"trellis"},
+			false,
+		},
+		{
+			"prefix_as_substring",
+			"xxx-trellis-yyy",
+			[]string{"trellis"},
+			false,
+		},
+		{
+			"end_with_prefix",
+			"xxx-trellis",
+			[]string{"trellis"},
+			false,
+		},
+		{
+			"underscore_as_separator",
+			"trellis_xxx",
+			[]string{"trellis"},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		output := hasValidPrefix(tc.filepath, tc.validPrefixes)
+
+		if output != tc.out {
+			t.Errorf("%s: expected output %t to be %t", tc.name, output, tc.out)
+		}
+	}
+}
+
+func TestIsUnderCoreRootCommands(t *testing.T) {
+	cases := []struct {
+		name             string
+		filepath         string
+		coreRootCommands []string
+		out              bool
+	}{
+		{
+			"same_as_core_root_command",
+			"trellis-foo",
+			[]string{"foo", "bar"},
+			true,
+		},
+		{
+			"subcommand_under_core_root_command",
+			"trellis-foo-xxx",
+			[]string{"foo", "bar"},
+			true,
+		},
+		{
+			"different_root_command",
+			"trellis-xxx",
+			[]string{"foo", "bar"},
+			false,
+		},
+		{
+			"subcommand_under_different_root_command",
+			"trellis-xxx-foo",
+			[]string{"foo", "bar"},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		output := isUnderCoreRootCommands(tc.filepath, tc.coreRootCommands)
+
+		if output != tc.out {
+			t.Errorf("%s: expected output %t to be %t", tc.name, output, tc.out)
+		}
+	}
+}

--- a/plugin/help_func.go
+++ b/plugin/help_func.go
@@ -1,0 +1,22 @@
+package plugin
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/mitchellh/cli"
+)
+
+func helpFunc(app string, pluginRootCommands []string) cli.HelpFunc {
+	return func(commands map[string]cli.CommandFactory) string {
+		var buf bytes.Buffer
+		if len(pluginRootCommands) > 0 {
+			buf.WriteString("\n\nAvailable third party plugin commands are:\n")
+		}
+
+		for _, p := range pluginRootCommands {
+			buf.WriteString(fmt.Sprintf("    %s\n", p))
+		}
+
+		return cli.BasicHelpFunc(app)(commands) + buf.String()
+	}
+}

--- a/plugin/help_func_test.go
+++ b/plugin/help_func_test.go
@@ -1,0 +1,45 @@
+package plugin
+
+import (
+	"github.com/mitchellh/cli"
+	"strings"
+	"testing"
+)
+
+func TestHelpFunc(t *testing.T) {
+	coreCommands := map[string]cli.CommandFactory{
+		"dummy": func() (cli.Command, error) {
+			return &cli.MockCommand{}, nil
+		},
+	}
+	pluginRootCommands := []string{"foo", "bar"}
+
+	output := helpFunc("app", pluginRootCommands)(coreCommands)
+
+	expected := "Available third party plugin commands are"
+	if !strings.Contains(output, expected) {
+		t.Errorf("expected output %q to contain %q", output, expected)
+	}
+
+	for _, plugin := range pluginRootCommands {
+		if !strings.Contains(output, plugin) {
+			t.Errorf("expected output %q to contain %q", output, plugin)
+		}
+	}
+}
+
+func TestHelpFuncNoPlugin(t *testing.T) {
+	coreCommands := map[string]cli.CommandFactory{
+		"dummy": func() (cli.Command, error) {
+			return &cli.MockCommand{}, nil
+		},
+	}
+	pluginRootCommands := []string{}
+
+	output := helpFunc("app", pluginRootCommands)(coreCommands)
+
+	expected := cli.BasicHelpFunc("app")(coreCommands)
+	if expected != output {
+		t.Errorf("expected output %q to be excatly the same as %q", output, expected)
+	}
+}

--- a/plugin/register.go
+++ b/plugin/register.go
@@ -1,0 +1,67 @@
+package plugin
+
+import (
+	"github.com/mitchellh/cli"
+	"reflect"
+	"strings"
+	"trellis-cli/cmd"
+)
+
+func Register(c *cli.CLI, searchPaths []string, validPluginFilenamePrefixes []string) {
+	coreRootCommands := rootCommandsFor(reflect.ValueOf(c.Commands))
+
+	pluginFinder := finder{
+		validPrefixes:    validPluginFilenamePrefixes,
+		searchPaths:      searchPaths,
+		coreRootCommands: coreRootCommands,
+	}
+	plugins := pluginFinder.find()
+	pluginRootCommands := rootCommandsFor(reflect.ValueOf(plugins))
+
+	// Register plugin commands.
+	for name, bin := range plugins {
+		pluginCommand := &cmd.PassthroughCommand{
+			Name: name,
+			Bin:  bin,
+			Args: c.Args,
+		}
+		c.Commands[name] = func() (cli.Command, error) {
+			return pluginCommand, nil
+		}
+	}
+
+	// Separate plugin commands from core command lists.
+	c.HiddenCommands = append(c.HiddenCommands, pluginRootCommands...)
+	// Append plugin command list to help text.
+	c.HelpFunc = helpFunc(c.Name, pluginRootCommands)
+}
+
+func rootCommandsFor(v reflect.Value) (rootCommands []string) {
+	m := v.MapKeys()
+
+	for _, v := range m {
+		rootCommand := strings.Split(v.String(), " ")[0]
+		rootCommands = append(rootCommands, rootCommand)
+	}
+
+	return unique(rootCommands)
+}
+
+// unique de-duplicates a given slice of strings without
+// sorting or otherwise altering its order in any way.
+func unique(values []string) (newValues []string) {
+	if len(values) == 0 {
+		return []string{}
+	}
+
+	seen := map[string]bool{}
+	for _, v := range values {
+		if seen[v] {
+			continue
+		}
+		seen[v] = true
+		newValues = append(newValues, v)
+	}
+
+	return
+}

--- a/plugin/register_test.go
+++ b/plugin/register_test.go
@@ -1,0 +1,274 @@
+package plugin
+
+import (
+	"fmt"
+	"github.com/mitchellh/cli"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"trellis-cli/cmd"
+)
+
+const spyCommand = `#!/usr/bin/env bash
+echo "i am plugin command"
+echo "total number of arguments passed: $#"
+echo "values of all the arguments passed: $@"
+`
+
+func TestIntegrationPluginCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	bin := os.Getenv("TEST_BINARY")
+	if bin == "" {
+		t.Error("TEST_BINARY not supplied")
+	}
+	if _, err := os.Stat(bin); os.IsNotExist(err) {
+		t.Error(bin + " not exist")
+	}
+
+	tempDir, err := ioutil.TempDir(os.TempDir(), "test-cmd-plugins")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// cleanup
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			panic(fmt.Errorf("unexpected cleanup error: %v", err))
+		}
+	}()
+
+	file, err := os.Create(filepath.Join(tempDir, "trellis-spy-foo"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := file.WriteString(spyCommand); err != nil {
+		file.Close()
+		t.Fatalf("unexpected error: %v", err)
+	}
+	file.Close()
+	err = os.Chmod(file.Name(), 0111)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cases := []struct {
+		name           string
+		args           []string
+		expectedStdOut []string
+		expectedStdErr []string
+	}{
+		{
+			"--help",
+			[]string{"--help"},
+			[]string{},
+			[]string{
+				"Available third party plugin commands are",
+				"spy",
+			},
+		},
+		{
+			"spy",
+			[]string{"spy"},
+			[]string{},
+			[]string{
+				"This command is accessed by using one of the subcommands below",
+				"foo",
+				"Third party plugin: Forward command to trellis-spy-foo",
+			},
+		},
+		{
+			"spy foo",
+			[]string{"spy", "foo"},
+			[]string{
+				"i am plugin command",
+				"total number of arguments passed: 0",
+				"values of all the arguments passed:",
+			},
+			[]string{},
+		},
+		{
+			"spy foo --help",
+			[]string{"spy", "foo", "--help"},
+			[]string{
+				"i am plugin command",
+				"total number of arguments passed: 1",
+				"values of all the arguments passed: --help",
+			},
+			[]string{},
+		},
+		{
+			"spy foo --aaa bbb --ccc ddd",
+			[]string{"spy", "foo", "--aaa", "bbb", "--ccc", "ddd"},
+			[]string{
+				"i am plugin command",
+				"total number of arguments passed: 4",
+				"values of all the arguments passed: --aaa bbb --ccc ddd",
+			},
+			[]string{},
+		},
+	}
+
+	for _, tc := range cases {
+		mockUi := cli.NewMockUi()
+		spyCommand := cmd.CommandExecWithOutput(bin, tc.args, mockUi)
+		spyCommand.Env = []string{"PATH=" + tempDir + ":" + os.ExpandEnv("$PATH")}
+
+		spyCommand.Run()
+
+		stdOut := mockUi.OutputWriter.String()
+		for _, expected := range tc.expectedStdOut {
+			if !strings.Contains(stdOut, expected) {
+				t.Errorf("$ trellis %s: expected stdOut %q to contain %q", tc.name, stdOut, expected)
+			}
+		}
+		stdErr := mockUi.ErrorWriter.String()
+		for _, expected := range tc.expectedStdErr {
+			if !strings.Contains(stdErr, expected) {
+				t.Errorf("$ trellis %s: expected stdErr %q to contain %q", tc.name, stdErr, expected)
+			}
+		}
+	}
+}
+
+func TestIntegrationPluginListInHelpFunc(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	bin := os.Getenv("TEST_BINARY")
+	if bin == "" {
+		t.Error("TEST_BINARY not supplied")
+	}
+	if _, err := os.Stat(bin); os.IsNotExist(err) {
+		t.Error(bin + " not exist")
+	}
+
+	tempDir, err := ioutil.TempDir(os.TempDir(), "test-cmd-plugins")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// cleanup
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			panic(fmt.Errorf("unexpected cleanup error: %v", err))
+		}
+	}()
+
+	createTempFile := func(name string, mode os.FileMode) (*os.File, error) {
+		file, err := os.Create(filepath.Join(tempDir, name))
+		if err != nil {
+			return nil, err
+		}
+
+		err = os.Chmod(file.Name(), mode)
+		if err != nil {
+			return nil, err
+		}
+
+		return file, nil
+	}
+
+	if _, err := createTempFile("trellis-foo", 0111); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := createTempFile("trellis-bar", 0111); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	mockUi := cli.NewMockUi()
+
+	trellisCommand := cmd.CommandExecWithOutput(bin, []string{"--help"}, mockUi)
+	trellisCommand.Env = []string{"PATH=" + tempDir + ":$PATH"}
+
+	trellisCommand.Run()
+	output := mockUi.ErrorWriter.String()
+
+	expected := "Available third party plugin commands are"
+	if !strings.Contains(output, expected) {
+		t.Errorf("expected output %q to contain %q", output, expected)
+	}
+	for _, plugin := range []string{"foo", "bar"} {
+		if !strings.Contains(output, plugin) {
+			t.Errorf("expected output %q to contain %q", output, plugin)
+		}
+	}
+}
+
+func TestRootCommandsFor(t *testing.T) {
+	cases := []struct {
+		in  map[string]string
+		out []string
+	}{
+		{
+			map[string]string{
+				"foo": "xxx",
+			},
+			[]string{"foo"},
+		},
+		{
+			map[string]string{
+				"foo": "xxx",
+				"bar": "yyy",
+			},
+			[]string{"foo", "bar"},
+		},
+		{
+			map[string]string{},
+			[]string{},
+		},
+	}
+
+	for _, tc := range cases {
+		output := rootCommandsFor(reflect.ValueOf(tc.in))
+
+		sort.Strings(output)
+		sort.Strings(tc.out)
+		if !reflect.DeepEqual(output, tc.out) {
+			t.Errorf("expected output %v to be %v", output, tc.out)
+		}
+	}
+}
+
+func TestUnique(t *testing.T) {
+	cases := []struct {
+		in  []string
+		out []string
+	}{
+		{
+			[]string{"foo"},
+			[]string{"foo"},
+		},
+		{
+			[]string{"foo", "bar"},
+			[]string{"foo", "bar"},
+		},
+		{
+			[]string{"foo", "foo", "foo", "bar"},
+			[]string{"foo", "bar"},
+		},
+		{
+			[]string{"foo", "bar", "", " ", "foo", "bar", "", " "},
+			[]string{"foo", "bar", "", " "},
+		},
+		{
+			[]string{},
+			[]string{},
+		},
+	}
+
+	for _, tc := range cases {
+		output := unique(tc.in)
+
+		sort.Strings(output)
+		sort.Strings(tc.out)
+		if !reflect.DeepEqual(output, tc.out) {
+			t.Errorf("expected output %v to be %v", output, tc.out)
+		}
+	}
+}


### PR DESCRIPTION
Inspired by https://github.com/kubernetes/kubectl/blob/b155278f1f4a21a0be2d4f6f0037258dee4d1a22/pkg/cmd/plugin/plugin.go and https://github.com/kubernetes/kubectl/blob/b155278f1f4a21a0be2d4f6f0037258dee4d1a22/pkg/cmd/cmd.go#L371

To test:
```bash
cd trellis-cli
go build

mkdir testing
ln -s $(which git) ./testing/trellis-git
echo "#\!/bin/bash\necho 'i am plugintest'" > testing/trellis-plugintest
echo "#\!/bin/bash\necho 'i am theplugin subtest'" > testing/trellis-theplugin-subtest
sudo chmod +x testing/trellis-plugintest
sudo chmod +x testing/trellis-theplugin-subtest


PATH="$(pwd)/testing:$PATH" ./trellis-cli
PATH="$(pwd)/testing:$PATH" ./trellis-cli plugintest
PATH="$(pwd)/testing:$PATH" ./trellis-cli theplugin subtest
PATH="$(pwd)/testing:$PATH" ./trellis-cli git 
PATH="$(pwd)/testing:$PATH" ./trellis-cli git log
PATH="$(pwd)/testing:$PATH" ./trellis-cli git log --help
PATH="$(pwd)/testing:$PATH" ./trellis-cli git help log
```

Related: #37 #145 
Close #36