### PR TITLE
Use goreleaser to set version number on build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,7 @@ builds:
     - CGO_ENABLED=0
   ldflags:
     - -X main.updaterRepo=roots/trellis-cli
+    - -X main.version={{ .Version }}
   goos:
     - linux
     - darwin

--- a/main.go
+++ b/main.go
@@ -17,8 +17,8 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-const version = "0.9.2"
-
+// To be replaced by goreleaser build flags.
+var version = "canary"
 var updaterRepo = ""
 
 func main() {


### PR DESCRIPTION
Goal: To avoid human mistakes.