### PR TITLE
Fix provision in dev for Vagrant

### DIFF
--- a/cmd/provision_test.go
+++ b/cmd/provision_test.go
@@ -86,19 +86,25 @@ func TestProvisionRun(t *testing.T) {
 		{
 			"default",
 			[]string{"development"},
-			"ansible-playbook server.yml -e env=development",
+			"ansible-playbook dev.yml -e env=development",
+			0,
+		},
+		{
+			"non_development",
+			[]string{"production"},
+			"ansible-playbook server.yml -e env=production",
 			0,
 		},
 		{
 			"with_tags",
 			[]string{"-tags", "users", "development"},
-			"ansible-playbook server.yml -e env=development --tags users",
+			"ansible-playbook dev.yml -e env=development --tags users",
 			0,
 		},
 		{
 			"with_extra_vars",
 			[]string{"-extra-vars", "k=v foo=bar", "development"},
-			"ansible-playbook server.yml -e env=development k=v foo=bar",
+			"ansible-playbook dev.yml -e env=development k=v foo=bar",
 			0,
 		},
 	}


### PR DESCRIPTION
The `provision` command used to always run the `server.yml` playbook regardless of environment which isn't correct for development where `dev.yml` should be used.

This sets `dev.yml` as the playbook for development and also specifies Vagrant's generated inventory file if it exists. This is needed for Vagrant boxes to use the proper user, host, port and private SSH key.