### PR TITLE
Add warning when project is not initialized

### DIFF
--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -3,6 +3,7 @@ package trellis
 import (
 	"errors"
 	"fmt"
+	"github.com/fatih/color"
 	"gopkg.in/ini.v1"
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
@@ -105,6 +106,18 @@ func (t *Trellis) LoadProject() error {
 	if os.Getenv("TRELLIS_VENV") != "false" {
 		if t.Virtualenv.Initialized() {
 			t.Virtualenv.Activate()
+		} else {
+			color.Yellow(`
+WARNING: no virtualenv found for this project. Trellis may not work as expected.
+To ensure you have the required dependencies, initialize the project with the following command:
+
+$ trellis init
+
+`)
+
+			color.Yellow(`To disable this automated check, set the TRELLIS_VENV environment variable to 'false': export TRELLIS_VENV=false
+
+`)
 		}
 	}
 


### PR DESCRIPTION
It's a common use case to start using trellis-cli on an existing Trellis project (meaning the project wasn't created from `trellis new`). In these cases, it's easy to miss that `trellis init` should be run to create a virtualenv and install dependencies.

This adds a warning message whenever a command is run and there's no virtualenv initialized that suggests users run `trellis init`. This is also just a helpful reminder in case someone knows about the init command but forgets, or the virtualenv gets deleted for some reason.

It can be disable by the existing `TRELLIS_VENV` environment variable.

<img width="1024" alt="image" src="https://user-images.githubusercontent.com/295605/145699725-8d43f3d1-4d09-4b47-9e40-291d0f8d0b97.png">

