### PR TITLE
Improve init command

### DIFF
--- a/cmd/db_open.go
+++ b/cmd/db_open.go
@@ -68,6 +68,8 @@ func (c *DBOpenCommand) Run(args []string) int {
 		return 1
 	}
 
+	c.Trellis.CheckVirtualenv(c.UI)
+
 	if err := c.flags.Parse(args); err != nil {
 		return 1
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -39,6 +39,8 @@ func (c *DeployCommand) Run(args []string) int {
 		return 1
 	}
 
+	c.Trellis.CheckVirtualenv(c.UI)
+
 	if err := c.flags.Parse(args); err != nil {
 		return 1
 	}

--- a/cmd/dot_env.go
+++ b/cmd/dot_env.go
@@ -37,6 +37,8 @@ func (c *DotEnvCommand) Run(args []string) int {
 		return 1
 	}
 
+	c.Trellis.CheckVirtualenv(c.UI)
+
 	commandArgumentValidator := &CommandArgumentValidator{required: 0, optional: 1}
 	commandArgumentErr := commandArgumentValidator.validate(args)
 	if commandArgumentErr != nil {

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -19,6 +19,8 @@ func (c *DownCommand) Run(args []string) int {
 		return 1
 	}
 
+	c.Trellis.CheckVirtualenv(c.UI)
+
 	commandArgumentValidator := &CommandArgumentValidator{required: 0, optional: 0}
 	commandArgumentErr := commandArgumentValidator.validate(args)
 	if commandArgumentErr != nil {

--- a/cmd/droplet_create.go
+++ b/cmd/droplet_create.go
@@ -60,6 +60,8 @@ func (c *DropletCreateCommand) Run(args []string) int {
 		return 1
 	}
 
+	c.Trellis.CheckVirtualenv(c.UI)
+
 	if err := c.flags.Parse(args); err != nil {
 		return 1
 	}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -22,6 +22,8 @@ func (c *ExecCommand) Run(args []string) int {
 		return 1
 	}
 
+	c.Trellis.CheckVirtualenv(c.UI)
+
 	var command string
 	var cmdArgs []string
 

--- a/cmd/galaxy_install.go
+++ b/cmd/galaxy_install.go
@@ -25,6 +25,8 @@ func (c *GalaxyInstallCommand) Run(args []string) int {
 		return 1
 	}
 
+	c.Trellis.CheckVirtualenv(c.UI)
+
 	commandArgumentValidator := &CommandArgumentValidator{required: 0, optional: 0}
 	commandArgumentErr := commandArgumentValidator.validate(args)
 	if commandArgumentErr != nil {

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -19,6 +19,8 @@ func (c *InfoCommand) Run(args []string) int {
 		return 1
 	}
 
+	c.Trellis.CheckVirtualenv(c.UI)
+
 	commandArgumentValidator := &CommandArgumentValidator{required: 0, optional: 0}
 	commandArgumentErr := commandArgumentValidator.validate(args)
 	if commandArgumentErr != nil {

--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -41,6 +41,8 @@ func (c *ProvisionCommand) Run(args []string) int {
 		return 1
 	}
 
+	c.Trellis.CheckVirtualenv(c.UI)
+
 	if err := c.flags.Parse(args); err != nil {
 		return 1
 	}

--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -36,6 +36,8 @@ func (c *RollbackCommand) Run(args []string) int {
 		return 1
 	}
 
+	c.Trellis.CheckVirtualenv(c.UI)
+
 	if err := c.flags.Parse(args); err != nil {
 		return 1
 	}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -37,6 +37,8 @@ func (c *UpCommand) Run(args []string) int {
 		return 1
 	}
 
+	c.Trellis.CheckVirtualenv(c.UI)
+
 	if err := c.flags.Parse(args); err != nil {
 		return 1
 	}

--- a/cmd/vault_decrypt.go
+++ b/cmd/vault_decrypt.go
@@ -36,6 +36,8 @@ func (c *VaultDecryptCommand) Run(args []string) int {
 		return 1
 	}
 
+	c.Trellis.CheckVirtualenv(c.UI)
+
 	if err := c.flags.Parse(args); err != nil {
 		return 1
 	}

--- a/cmd/vault_edit.go
+++ b/cmd/vault_edit.go
@@ -19,6 +19,8 @@ func (c *VaultEditCommand) Run(args []string) int {
 		return 1
 	}
 
+	c.Trellis.CheckVirtualenv(c.UI)
+
 	commandArgumentValidator := &CommandArgumentValidator{required: 1, optional: 0}
 	commandArgumentErr := commandArgumentValidator.validate(args)
 	if commandArgumentErr != nil {

--- a/cmd/vault_encrypt.go
+++ b/cmd/vault_encrypt.go
@@ -37,6 +37,8 @@ func (c *VaultEncryptCommand) Run(args []string) int {
 		return 1
 	}
 
+	c.Trellis.CheckVirtualenv(c.UI)
+
 	if err := c.flags.Parse(args); err != nil {
 		return 1
 	}

--- a/cmd/vault_view.go
+++ b/cmd/vault_view.go
@@ -35,6 +35,8 @@ func (c *VaultViewCommand) Run(args []string) int {
 		return 1
 	}
 
+	c.Trellis.CheckVirtualenv(c.UI)
+
 	if err := c.flags.Parse(args); err != nil {
 		return 1
 	}

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ func main() {
 
 	ui := &cli.ColoredUi{
 		ErrorColor: cli.UiColorRed,
+		WarnColor:  cli.UiColor{Code: int(color.FgYellow), Bold: false},
 		Ui: &cli.BasicUi{
 			Reader:      os.Stdin,
 			Writer:      os.Stdout,

--- a/trellis/virtualenv.go
+++ b/trellis/virtualenv.go
@@ -10,10 +10,11 @@ import (
 	"github.com/roots/trellis-cli/github"
 )
 
-const VirtualenvDir string = "virtualenv"
+const TrellisVenvEnvName string = "TRELLIS_VENV"
 const VenvEnvName string = "VIRTUAL_ENV"
 const PathEnvName string = "PATH"
 const OldPathEnvName string = "PRE_TRELLIS_PATH"
+const VirtualenvDir string = "virtualenv"
 
 type Virtualenv struct {
 	Path    string


### PR DESCRIPTION
Mainly this avoids showing the newly added warning about the virtualenv not existing while running the `init` command. If the warning tells users to run `trellis init`, then we shouldn't show the warning _again_ once they run it.

This also improves the output a bit by removing a redundant pip command line. There's also a final error message as well if `pip` fails.

Before (success):
<img width="1146" alt="image" src="https://user-images.githubusercontent.com/295605/145747239-07da78c7-1a86-474e-a76b-61e7842a1e37.png">

Before (error):
<img width="1421" alt="image" src="https://user-images.githubusercontent.com/295605/145747282-29322a39-1c1f-4da7-9fca-86452f249b97.png">


After (success):
<img width="899" alt="image" src="https://user-images.githubusercontent.com/295605/145747145-59f350fa-ca16-482d-bd28-bfc054bcd1e5.png">

After (error):
<img width="916" alt="image" src="https://user-images.githubusercontent.com/295605/145747317-90d3c9d7-0064-4d69-97ff-eb8bf0f84448.png">
