### PR TITLE
Set VenvInitialized within init command

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -56,6 +56,7 @@ func (c *InitCommand) Run(args []string) int {
 			return 1
 		}
 
+		c.Trellis.VenvInitialized = true
 		c.UI.Info(color.GreenString("✓ virtualenv created"))
 	}
 


### PR DESCRIPTION
Setting this prevents the venv uninintialized warning in situations where the `init` command is run from within another one. Mainly this prevents the warnings from appearing during `trellis new`.