### PR TITLE
Fix CLI autocompletion

### DIFF
--- a/trellis/complete.go
+++ b/trellis/complete.go
@@ -19,9 +19,9 @@ func (t *Trellis) PredictSite() complete.PredictFunc {
 		}
 
 		switch len(args.Completed) {
-		case 1:
+		case 0:
 			return t.EnvironmentNames()
-		case 2:
+		case 1:
 			return t.SiteNamesFromEnvironment(args.LastCompleted)
 		default:
 			return []string{}
@@ -36,7 +36,7 @@ func (t *Trellis) PredictEnvironment() complete.PredictFunc {
 		}
 
 		switch len(args.Completed) {
-		case 1:
+		case 0:
 			return t.EnvironmentNames()
 		default:
 			return []string{}


### PR DESCRIPTION
https://github.com/roots/trellis-cli/pull/146 broke autocompletion by bumping the `complete` package version which included this change: https://github.com/posener/complete/pull/102.

Previously this worked around the off-by-one error, but after it was fixed, we were off by one 🙃 


This also refactors the completion tests to be more integration-style tests that would have caught this breaking change by running completions through the full CLI execution.