### PR TITLE
Refactor Trellis constructor

### DIFF
--- a/cmd/alias_test.go
+++ b/cmd/alias_test.go
@@ -39,8 +39,7 @@ func TestAliasArgumentValidations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			mockProject := &MockProject{tc.projectDetected}
-			trellis := trellis.NewTrellis(mockProject)
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
 
 			aliasCommand := &AliasCommand{UI: ui, Trellis: trellis, aliasPlaybook: &MockPlaybook{ui: ui}, aliasCopyPlaybook: &MockPlaybook{ui: ui}}
 			aliasCommand.init()

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -10,14 +10,6 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-type MockProject struct {
-	detected bool
-}
-
-func (p *MockProject) Detect(path string) (projectPath string, ok bool) {
-	return "trellis", p.detected
-}
-
 func mockExecCommand(command string, args []string, ui cli.Ui) *exec.Cmd {
 	cs := []string{"-test.run=TestHelperProcess", "--", command}
 	cs = append(cs, args...)

--- a/cmd/db_open_test.go
+++ b/cmd/db_open_test.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
-	"github.com/mitchellh/cli"
-	"github.com/roots/trellis-cli/trellis"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/mitchellh/cli"
+	"github.com/roots/trellis-cli/trellis"
 )
 
 func TestDBOpenArgumentValidations(t *testing.T) {
@@ -35,8 +36,7 @@ func TestDBOpenArgumentValidations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			mockProject := &MockProject{tc.projectDetected}
-			trellis := trellis.NewTrellis(mockProject)
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
 
 			dbOpenCommand := &DBOpenCommand{UI: ui, Trellis: trellis, dbOpenerFactory: &DBOpenerFactory{}, playbook: &MockPlaybook{ui: ui}}
 			dbOpenCommand.init()
@@ -59,8 +59,7 @@ func TestDBOpenAppFlagValidations(t *testing.T) {
 	defer trellis.LoadFixtureProject(t)()
 
 	ui := cli.NewMockUi()
-	project := &trellis.Project{}
-	trellis := trellis.NewTrellis(project)
+	trellis := trellis.NewTrellis()
 
 	dbOpenCommand := &DBOpenCommand{UI: ui, Trellis: trellis, dbOpenerFactory: &DBOpenerFactory{}, playbook: &MockPlaybook{ui: ui}}
 	dbOpenCommand.init()
@@ -83,8 +82,7 @@ func TestDBOpenPlaybook(t *testing.T) {
 	defer trellis.LoadFixtureProject(t)()
 
 	ui := cli.NewMockUi()
-	project := &trellis.Project{}
-	trellis := trellis.NewTrellis(project)
+	trellis := trellis.NewTrellis()
 	mockPlaybook := &MockPlaybook{ui: ui}
 	dbOpenerFactory := &DBOpenerFactory{}
 

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -65,8 +65,7 @@ func TestDeployRunValidations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			mockProject := &MockProject{tc.projectDetected}
-			trellis := trellis.NewTrellis(mockProject)
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
 			deployCommand := NewDeployCommand(ui, trellis)
 
 			code := deployCommand.Run(tc.args)
@@ -86,8 +85,7 @@ func TestDeployRunValidations(t *testing.T) {
 
 func TestDeployRun(t *testing.T) {
 	defer trellis.LoadFixtureProject(t)()
-	project := &trellis.Project{}
-	trellis := trellis.NewTrellis(project)
+	trellis := trellis.NewTrellis()
 
 	defer MockExec(t)()
 

--- a/cmd/dot_env_test.go
+++ b/cmd/dot_env_test.go
@@ -39,8 +39,7 @@ func TestDotEnvArgumentValidations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			mockProject := &MockProject{tc.projectDetected}
-			trellis := trellis.NewTrellis(mockProject)
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
 
 			dotEnvCommand := DotEnvCommand{UI: ui, Trellis: trellis, playbook: &MockPlaybook{ui: ui}}
 
@@ -81,8 +80,7 @@ func TestDotEnvInvalidEnvironmentArgument(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			mockProject := &MockProject{tc.projectDetected}
-			trellis := trellis.NewTrellis(mockProject)
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
 
 			dotEnvCommand := DotEnvCommand{UI: ui, Trellis: trellis, playbook: &MockPlaybook{ui: ui}}
 
@@ -103,8 +101,7 @@ func TestDotEnvInvalidEnvironmentArgument(t *testing.T) {
 
 func TestDotEnvRun(t *testing.T) {
 	defer trellis.LoadFixtureProject(t)()
-	project := &trellis.Project{}
-	trellis := trellis.NewTrellis(project)
+	trellis := trellis.NewTrellis()
 
 	defer MockExec(t)()
 

--- a/cmd/down_test.go
+++ b/cmd/down_test.go
@@ -35,8 +35,7 @@ func TestDownRunValidations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			mockProject := &MockProject{tc.projectDetected}
-			trellis := trellis.NewTrellis(mockProject)
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
 			downCommand := &DownCommand{ui, trellis}
 
 			code := downCommand.Run(tc.args)
@@ -55,8 +54,7 @@ func TestDownRunValidations(t *testing.T) {
 }
 
 func TestDownRun(t *testing.T) {
-	mockProject := &MockProject{true}
-	trellis := trellis.NewTrellis(mockProject)
+	trellis := trellis.NewMockTrellis(true)
 
 	defer MockExec(t)()
 

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -28,8 +28,7 @@ func TestExecRunValidations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			mockProject := &MockProject{tc.projectDetected}
-			trellis := trellis.NewTrellis(mockProject)
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
 			execCommand := &ExecCommand{ui, trellis}
 
 			code := execCommand.Run(tc.args)

--- a/cmd/galaxy_install_test.go
+++ b/cmd/galaxy_install_test.go
@@ -36,8 +36,7 @@ func TestGalaxyInstallRunValidations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			mockProject := &MockProject{tc.projectDetected}
-			trellis := trellis.NewTrellis(mockProject)
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
 			galaxyInstallCommand := GalaxyInstallCommand{ui, trellis}
 
 			code := galaxyInstallCommand.Run(tc.args)
@@ -100,8 +99,7 @@ func TestGalaxyInstallRun(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			project := &trellis.Project{}
-			trellis := trellis.NewTrellis(project)
+			trellis := trellis.NewTrellis()
 			galaxyInstallCommand := GalaxyInstallCommand{ui, trellis}
 
 			for _, file := range tc.roleFiles {

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -35,8 +35,7 @@ func TestInitRunValidations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			mockProject := &MockProject{tc.projectDetected}
-			trellis := trellis.NewTrellis(mockProject)
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
 			initCommand := &InitCommand{ui, trellis}
 
 			code := initCommand.Run(tc.args)

--- a/cmd/new_test.go
+++ b/cmd/new_test.go
@@ -36,8 +36,7 @@ func TestNewRunValidations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			mockProject := &MockProject{tc.projectDetected}
-			trellis := trellis.NewTrellis(mockProject)
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
 			newCommand := NewNewCommand(ui, trellis, "1.0.0")
 
 			code := newCommand.Run(tc.args)

--- a/cmd/provision_test.go
+++ b/cmd/provision_test.go
@@ -51,8 +51,7 @@ func TestProvisionRunValidations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			mockProject := &MockProject{tc.projectDetected}
-			trellis := trellis.NewTrellis(mockProject)
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
 			provisionCommand := NewProvisionCommand(ui, trellis)
 
 			code := provisionCommand.Run(tc.args)
@@ -72,8 +71,7 @@ func TestProvisionRunValidations(t *testing.T) {
 
 func TestProvisionRun(t *testing.T) {
 	defer trellis.LoadFixtureProject(t)()
-	project := &trellis.Project{}
-	trellis := trellis.NewTrellis(project)
+	trellis := trellis.NewTrellis()
 
 	defer MockExec(t)()
 

--- a/cmd/rollback_test.go
+++ b/cmd/rollback_test.go
@@ -65,8 +65,7 @@ func TestRollbackRunValidations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			mockProject := &MockProject{tc.projectDetected}
-			trellis := trellis.NewTrellis(mockProject)
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
 			rollbackCommand := NewRollbackCommand(ui, trellis)
 
 			code := rollbackCommand.Run(tc.args)
@@ -86,8 +85,7 @@ func TestRollbackRunValidations(t *testing.T) {
 
 func TestRollbackRun(t *testing.T) {
 	defer trellis.LoadFixtureProject(t)()
-	project := &trellis.Project{}
-	trellis := trellis.NewTrellis(project)
+	trellis := trellis.NewTrellis()
 
 	defer MockExec(t)()
 

--- a/cmd/ssh_test.go
+++ b/cmd/ssh_test.go
@@ -65,8 +65,7 @@ func TestSshRunValidations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			mockProject := &MockProject{tc.projectDetected}
-			trellis := trellis.NewTrellis(mockProject)
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
 			sshCommand := &SshCommand{ui, trellis}
 
 			defer MockExec(t)()
@@ -90,8 +89,7 @@ func TestSshRun(t *testing.T) {
 	defer trellis.LoadFixtureProject(t)()
 	defer MockExec(t)()
 
-	project := &trellis.Project{}
-	trellis := trellis.NewTrellis(project)
+	trellis := trellis.NewTrellis()
 
 	cases := []struct {
 		name string

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -35,8 +35,7 @@ func TestUpRunValidations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			mockProject := &MockProject{tc.projectDetected}
-			trellis := trellis.NewTrellis(mockProject)
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
 			upCommand := NewUpCommand(ui, trellis)
 
 			code := upCommand.Run(tc.args)
@@ -55,8 +54,7 @@ func TestUpRunValidations(t *testing.T) {
 }
 
 func TestUpRun(t *testing.T) {
-	mockProject := &MockProject{true}
-	trellis := trellis.NewTrellis(mockProject)
+	trellis := trellis.NewMockTrellis(true)
 
 	defer MockExec(t)()
 

--- a/cmd/valet_link_test.go
+++ b/cmd/valet_link_test.go
@@ -35,8 +35,7 @@ func TestValetLinkArgumentValidations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			mockProject := &MockProject{tc.projectDetected}
-			trellis := trellis.NewTrellis(mockProject)
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
 
 			valetLinkCommand := ValetLinkCommand{ui, trellis}
 
@@ -81,8 +80,7 @@ func TestValetLinkValidEnvironmentArgument(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			mockProject := &MockProject{tc.projectDetected}
-			trellis := trellis.NewTrellis(mockProject)
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
 
 			valetLinkCommand := ValetLinkCommand{ui, trellis}
 
@@ -119,8 +117,7 @@ func TestValetLinkInvalidEnvironmentArgument(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			mockProject := &MockProject{tc.projectDetected}
-			trellis := trellis.NewTrellis(mockProject)
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
 
 			valetLinkCommand := ValetLinkCommand{ui, trellis}
 
@@ -141,8 +138,7 @@ func TestValetLinkInvalidEnvironmentArgument(t *testing.T) {
 
 func TestValetLinkRun(t *testing.T) {
 	ui := cli.NewMockUi()
-	project := &trellis.Project{}
-	trellisProject := trellis.NewTrellis(project)
+	trellisProject := trellis.NewTrellis()
 
 	defer trellis.TestChdir(t, "../trellis/testdata/trellis")()
 
@@ -152,8 +148,7 @@ func TestValetLinkRun(t *testing.T) {
 
 	defer MockExec(t)()
 
-	mockProject := &MockProject{true}
-	trellis := trellis.NewTrellis(mockProject)
+	trellis := trellis.NewMockTrellis(true)
 
 	valetLinkCommand := ValetLinkCommand{ui, trellis}
 

--- a/cmd/vault_decrypt_test.go
+++ b/cmd/vault_decrypt_test.go
@@ -35,8 +35,7 @@ func TestVaultDecryptRunValidations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			mockProject := &MockProject{tc.projectDetected}
-			trellis := trellis.NewTrellis(mockProject)
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
 			vaultDecryptCommand := NewVaultDecryptCommand(ui, trellis)
 
 			code := vaultDecryptCommand.Run(tc.args)
@@ -57,8 +56,7 @@ func TestVaultDecryptRunValidations(t *testing.T) {
 func TestVaultDecryptRun(t *testing.T) {
 	defer MockExec(t)()
 
-	project := &trellis.Project{}
-	trellisProject := trellis.NewTrellis(project)
+	trellisProject := trellis.NewTrellis()
 
 	defer trellis.TestChdir(t, "../trellis/testdata/trellis")()
 

--- a/cmd/vault_edit_test.go
+++ b/cmd/vault_edit_test.go
@@ -35,8 +35,7 @@ func TestVaultEditRunValidations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			mockProject := &MockProject{tc.projectDetected}
-			trellis := trellis.NewTrellis(mockProject)
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
 			vaultEditCommand := VaultEditCommand{ui, trellis}
 
 			code := vaultEditCommand.Run(tc.args)
@@ -58,8 +57,7 @@ func TestVaultEditRun(t *testing.T) {
 	defer trellis.LoadFixtureProject(t)()
 	defer MockExec(t)()
 
-	project := &trellis.Project{}
-	trellis := trellis.NewTrellis(project)
+	trellis := trellis.NewTrellis()
 
 	cases := []struct {
 		name string

--- a/cmd/vault_encrypt_test.go
+++ b/cmd/vault_encrypt_test.go
@@ -34,8 +34,7 @@ func TestVaultEncryptRunValidations(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			mockProject := &MockProject{tc.projectDetected}
-			trellis := trellis.NewTrellis(mockProject)
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
 			ui := cli.NewMockUi()
 			vaultEncryptCommand := NewVaultEncryptCommand(ui, trellis)
 
@@ -57,8 +56,7 @@ func TestVaultEncryptRunValidations(t *testing.T) {
 func TestVaultEncryptRun(t *testing.T) {
 	defer MockExec(t)()
 
-	project := &trellis.Project{}
-	trellisProject := trellis.NewTrellis(project)
+	trellisProject := trellis.NewTrellis()
 
 	defer trellis.TestChdir(t, "../trellis/testdata/trellis")()
 

--- a/cmd/vault_view_test.go
+++ b/cmd/vault_view_test.go
@@ -35,8 +35,7 @@ func TestVaultViewRunValidations(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
-			mockProject := &MockProject{tc.projectDetected}
-			trellis := trellis.NewTrellis(mockProject)
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
 			vaultViewCommand := NewVaultViewCommand(ui, trellis)
 
 			code := vaultViewCommand.Run(tc.args)
@@ -55,8 +54,7 @@ func TestVaultViewRunValidations(t *testing.T) {
 }
 
 func TestVaultViewRun(t *testing.T) {
-	project := &trellis.Project{}
-	trellisProject := trellis.NewTrellis(project)
+	trellisProject := trellis.NewTrellis()
 
 	defer trellis.TestChdir(t, "../trellis/testdata/trellis")()
 
@@ -66,8 +64,7 @@ func TestVaultViewRun(t *testing.T) {
 
 	defer MockExec(t)()
 
-	mockProject := &MockProject{true}
-	trellis := trellis.NewTrellis(mockProject)
+	trellis := trellis.NewMockTrellis(true)
 
 	cases := []struct {
 		name string

--- a/cmd/venv_hook_test.go
+++ b/cmd/venv_hook_test.go
@@ -14,8 +14,7 @@ func TestVenvHookRunActivatesEnv(t *testing.T) {
 	defer trellis.LoadFixtureProject(t)()
 
 	ui := cli.NewMockUi()
-	project := &trellis.Project{}
-	tp := trellis.NewTrellis(project)
+	tp := trellis.NewTrellis()
 	venvHookCommand := &VenvHookCommand{ui, tp}
 
 	code := venvHookCommand.Run([]string{})
@@ -41,8 +40,7 @@ func TestVenvHookRunDeactivatesEnv(t *testing.T) {
 	os.Setenv(trellis.OldPathEnvName, "foo")
 
 	ui := cli.NewMockUi()
-	mockProject := &MockProject{false}
-	trellis := trellis.NewTrellis(mockProject)
+	trellis := trellis.NewMockTrellis(false)
 	venvHookCommand := &VenvHookCommand{ui, trellis}
 
 	code := venvHookCommand.Run([]string{})
@@ -67,8 +65,7 @@ func TestVenvHookRunWithoutProject(t *testing.T) {
 	os.Unsetenv(trellis.OldPathEnvName)
 
 	ui := cli.NewMockUi()
-	mockProject := &MockProject{false}
-	trellis := trellis.NewTrellis(mockProject)
+	trellis := trellis.NewMockTrellis(false)
 	venvHookCommand := &VenvHookCommand{ui, trellis}
 
 	code := venvHookCommand.Run([]string{})

--- a/main.go
+++ b/main.go
@@ -2,15 +2,16 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
 	"github.com/roots/trellis-cli/cmd"
 	"github.com/roots/trellis-cli/config"
 	"github.com/roots/trellis-cli/github"
 	"github.com/roots/trellis-cli/plugin"
 	"github.com/roots/trellis-cli/trellis"
 	"github.com/roots/trellis-cli/update"
-	"os"
-	"path/filepath"
-	"strconv"
 
 	"github.com/fatih/color"
 	"github.com/mitchellh/cli"
@@ -49,8 +50,7 @@ func main() {
 		},
 	}
 
-	project := &trellis.Project{}
-	trellis := trellis.NewTrellis(project)
+	trellis := trellis.NewTrellis()
 
 	c.Commands = map[string]cli.CommandFactory{
 		"alias": func() (cli.Command, error) {

--- a/trellis/complete_test.go
+++ b/trellis/complete_test.go
@@ -21,8 +21,7 @@ import (
 const envComplete = "COMP_LINE"
 
 func TestCompletionFunctions(t *testing.T) {
-	project := &Project{}
-	trellis := NewTrellis(project)
+	trellis := NewTrellis()
 
 	defer TestChdir(t, "testdata/trellis")()
 

--- a/trellis/detector.go
+++ b/trellis/detector.go
@@ -9,16 +9,14 @@ type Detector interface {
 	Detect(path string) (projectPath string, ok bool)
 }
 
-type Project struct{}
-
-const GlobPattern = "group_vars/*/wordpress_sites.yml"
+type ProjectDetector struct{}
 
 /*
 Detect if a path is a Trellis project or not
 This will traverse up the directory tree until it finds a valid project,
 or stop at the root and give up.
 */
-func (p *Project) Detect(path string) (projectPath string, ok bool) {
+func (p *ProjectDetector) Detect(path string) (projectPath string, ok bool) {
 	configPaths, _ := filepath.Glob(filepath.Join(path, GlobPattern))
 
 	if len(configPaths) == 0 {
@@ -38,7 +36,7 @@ func (p *Project) Detect(path string) (projectPath string, ok bool) {
 	return path, true
 }
 
-func (p *Project) detectTrellisCLIProject(path string) bool {
+func (p *ProjectDetector) detectTrellisCLIProject(path string) bool {
 	trellisPath := filepath.Join(path, "trellis")
 	sitePath := filepath.Join(path, "site")
 	configPath := filepath.Join(trellisPath, ConfigDir)

--- a/trellis/detector_test.go
+++ b/trellis/detector_test.go
@@ -25,7 +25,7 @@ func TestDetect(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	project := &Project{}
+	project := &ProjectDetector{}
 
 	cases := []struct {
 		name         string
@@ -84,7 +84,7 @@ func TestDetectTrellisProjectStructure(t *testing.T) {
 	devConfig := filepath.Join(devDir, "wordpress_sites.yml")
 	ioutil.WriteFile(devConfig, []byte{}, 0666)
 
-	project := &Project{}
+	project := &ProjectDetector{}
 
 	cases := []struct {
 		name         string

--- a/trellis/hosts_test.go
+++ b/trellis/hosts_test.go
@@ -8,8 +8,7 @@ import (
 func TestUpdateHosts(t *testing.T) {
 	defer TestChdir(t, "testdata/trellis")()
 
-	project := &Project{}
-	trellis := NewTrellis(project)
+	trellis := NewTrellis()
 
 	err := trellis.LoadProject()
 	if err != nil {

--- a/trellis/mock_detector.go
+++ b/trellis/mock_detector.go
@@ -1,0 +1,9 @@
+package trellis
+
+type MockProjectDetector struct {
+	detected bool
+}
+
+func (p *MockProjectDetector) Detect(path string) (projectPath string, ok bool) {
+	return "trellis", p.detected
+}

--- a/trellis/trellis_test.go
+++ b/trellis/trellis_test.go
@@ -13,7 +13,7 @@ func TestCreateConfigDir(t *testing.T) {
 	configPath := dir + "/testing-trellis-create-config-dir"
 
 	trellis := Trellis{
-		ConfigPath: configPath,
+		ConfigDir: configPath,
 	}
 
 	trellis.CreateConfigDir()
@@ -240,8 +240,7 @@ func TestSiteFromEnvironmentAndName(t *testing.T) {
 func TestActivateProjectProjects(t *testing.T) {
 	defer LoadFixtureProject(t)()
 
-	project := &Project{}
-	tp := NewTrellis(project)
+	tp := NewTrellis()
 
 	if !tp.ActivateProject() {
 		t.Error("expected true")
@@ -257,8 +256,7 @@ func TestActivateProjectForNonProjects(t *testing.T) {
 	defer TestChdir(t, tempDir)()
 	defer os.RemoveAll(tempDir)
 
-	project := &Project{}
-	tp := NewTrellis(project)
+	tp := NewTrellis()
 
 	if tp.ActivateProject() {
 		t.Error("expected false")
@@ -269,8 +267,7 @@ func TestActivateProjectForNonVirtualenvInitializedProjects(t *testing.T) {
 	defer LoadFixtureProject(t)()
 	os.RemoveAll(".trellis/virtualenv")
 
-	project := &Project{}
-	tp := NewTrellis(project)
+	tp := NewTrellis()
 
 	if tp.ActivateProject() {
 		t.Error("expected false")


### PR DESCRIPTION
Refactor that improves the `NewTrellis` constructor with more flexible options and eliminates the need to manually create a (confusingly named) `Project` instance too. This enables a simpler `NewMockTrellis` constructor which sets the mock detector as well.