### PR TITLE
Add open command

### DIFF
--- a/cmd/open.go
+++ b/cmd/open.go
@@ -1,0 +1,149 @@
+package cmd
+
+import (
+	"fmt"
+	"runtime"
+	"sort"
+	"strings"
+
+	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/roots/trellis-cli/trellis"
+)
+
+type OpenCommand struct {
+	UI      cli.Ui
+	Trellis *trellis.Trellis
+}
+
+func (c *OpenCommand) Run(args []string) int {
+	if err := c.Trellis.LoadProject(); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	commandArgumentValidator := &CommandArgumentValidator{required: 0, optional: 1}
+	commandArgumentErr := commandArgumentValidator.validate(args)
+	if commandArgumentErr != nil {
+		c.UI.Error(commandArgumentErr.Error())
+		c.UI.Output(c.Help())
+		return 1
+	}
+
+	var openArgs = []string{}
+
+	if len(args) == 0 {
+		siteName, siteNameErr := c.Trellis.FindSiteNameFromEnvironment("development", "")
+		if siteNameErr != nil {
+			c.UI.Error(siteNameErr.Error())
+			return 1
+		}
+
+		url := c.Trellis.SiteFromEnvironmentAndName("development", siteName).MainUrl()
+		openArgs = []string{url}
+	} else {
+		value, exists := c.Trellis.CliConfig.Open[args[0]]
+
+		if !exists {
+			c.UI.Error(fmt.Sprintf("Error: shortcut '%s' does not exist. Check your .trellis/cli.yml config file.", args[0]))
+			c.UI.Error(fmt.Sprintf("Valid shortcuts are: %s", strings.Join(openNames(c.Trellis.CliConfig.Open), ", ")))
+			return 1
+		}
+
+		openArgs = []string{value}
+	}
+
+	openCommandName := OpenCommandName()
+
+	if openCommandName == "" {
+		c.UI.Error("Error: open command only supported on macOS and Linux")
+		return 1
+	}
+
+	open := execCommand(openCommandName, openArgs, c.UI)
+	err := open.Run()
+
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error running open: %s", err))
+		return 1
+	}
+
+	return 0
+}
+
+func (c *OpenCommand) Synopsis() string {
+	return "Opens user-defined URLs (and more) which can act as shortcuts/bookmarks specific to your Trellis projects."
+}
+
+func (c *OpenCommand) Help() string {
+	helpText := `
+Usage: trellis open [options] [NAME]
+
+Opens user-defined URLs (and more) which can act as shortcuts/bookmarks specific to your Trellis projects.
+
+Without any arguments provided, this defaults to opening the main site's development canonical URL.
+
+Additional entries can be customized by adding them to your project's config file (in '.trellis/cli.yml'):
+
+  open:
+    sentry: https://myapp.sentry.io
+    newrelic: https://myapp.newrelic.com
+
+Opens the main site's canonical URL in your web browser:
+
+  $ trellis open
+
+Opens the 'newrelic' shortcut (defined in config):
+
+  $ trellis open newrelic
+
+Arguments:
+  NAME Name of shortcut
+
+Options:
+  -h, --help  show this help
+`
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *OpenCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictFunc(func(args complete.Args) []string {
+		if err := c.Trellis.LoadProject(); err != nil {
+			return []string{}
+		}
+
+		switch len(args.Completed) {
+		case 0:
+			return openNames(c.Trellis.CliConfig.Open)
+		default:
+			return []string{}
+		}
+	})
+}
+
+func (c *OpenCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{}
+}
+
+func openNames(config map[string]string) []string {
+	var names []string
+
+	for key := range config {
+		names = append(names, key)
+	}
+
+	sort.Strings(names)
+	return names
+}
+
+func OpenCommandName() (commandName string) {
+	switch runtime.GOOS {
+	case "darwin":
+		commandName = "open"
+	case "linux":
+		commandName = "xdg-open"
+	}
+
+	return commandName
+}

--- a/cmd/open_test.go
+++ b/cmd/open_test.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/cli"
+	"github.com/roots/trellis-cli/trellis"
+)
+
+func TestOpenRunValidations(t *testing.T) {
+	ui := cli.NewMockUi()
+
+	cases := []struct {
+		name            string
+		projectDetected bool
+		args            []string
+		out             string
+		code            int
+	}{
+		{
+			"no_project",
+			false,
+			nil,
+			"No Trellis project detected",
+			1,
+		},
+		{
+			"too_many_args",
+			true,
+			[]string{"foo", "bar"},
+			"Error: too many arguments",
+			1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
+			downCommand := &OpenCommand{ui, trellis}
+
+			code := downCommand.Run(tc.args)
+
+			if code != tc.code {
+				t.Errorf("expected code %d to be %d", code, tc.code)
+			}
+
+			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+
+			if !strings.Contains(combined, tc.out) {
+				t.Errorf("expected output %q to contain %q", combined, tc.out)
+			}
+		})
+	}
+}
+
+func TestOpenRun(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
+	trellis := trellis.NewTrellis()
+
+	defer MockExec(t)()
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			"default",
+			[]string{},
+			fmt.Sprintf("%s http://example.test", OpenCommandName()),
+			0,
+		},
+		{
+			"invalid_shortcut_name",
+			[]string{"invalid"},
+			"Error: shortcut 'invalid' does not exist.",
+			1,
+		},
+		{
+			"shortcut_from_confi",
+			[]string{"sentry"},
+			fmt.Sprintf("%s https://myapp.sentry.io", OpenCommandName()),
+			0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ui := cli.NewMockUi()
+			downCommand := &OpenCommand{ui, trellis}
+			code := downCommand.Run(tc.args)
+
+			if code != tc.code {
+				t.Errorf("expected code %d to be %d", code, tc.code)
+			}
+
+			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+
+			if !strings.Contains(combined, tc.out) {
+				t.Errorf("expected output %q to contain %q", combined, tc.out)
+			}
+		})
+	}
+}

--- a/cmd/valet_link.go
+++ b/cmd/valet_link.go
@@ -49,11 +49,9 @@ func (c *ValetLinkCommand) Run(args []string) int {
 		canonical, _ := c.Trellis.HostsFromDomain(site.SiteHosts[0].Canonical, environment)
 		app := strings.TrimSuffix(canonical.String(), "."+canonical.TLD)
 
-		isSiteSslEnabled := site.Ssl["enabled"] == true
-
 		valetArgs := []string{"link"}
 
-		if isSiteSslEnabled {
+		if site.SslEnabled() {
 			valetArgs = append(valetArgs, "--secure")
 		}
 		valetArgs = append(valetArgs, app)

--- a/main.go
+++ b/main.go
@@ -107,6 +107,9 @@ func main() {
 		"new": func() (cli.Command, error) {
 			return cmd.NewNewCommand(ui, trellis, c.Version), nil
 		},
+		"open": func() (cli.Command, error) {
+			return &cmd.OpenCommand{UI: ui, Trellis: trellis}, nil
+		},
 		"provision": func() (cli.Command, error) {
 			return cmd.NewProvisionCommand(ui, trellis), nil
 		},

--- a/trellis/cli_config.go
+++ b/trellis/cli_config.go
@@ -1,4 +1,5 @@
 package trellis
 
 type CliConfig struct {
+	Open map[string]string `yaml:"open"`
 }

--- a/trellis/config.go
+++ b/trellis/config.go
@@ -22,8 +22,22 @@ type Site struct {
 	Cache           map[string]interface{} `yaml:"cache"`
 }
 
+func (s *Site) SslEnabled() bool {
+	return s.Ssl["enabled"] == true
+}
+
 func (s *Site) MainHost() string {
 	return s.SiteHosts[0].Canonical
+}
+
+func (s *Site) MainUrl() string {
+	var protocol string = "http"
+
+	if s.SslEnabled() {
+		protocol = "https"
+	}
+
+	return fmt.Sprintf("%s://%s", protocol, s.SiteHosts[0].Canonical)
 }
 
 type SiteHost struct {

--- a/trellis/testdata/trellis/.trellis/cli.yml
+++ b/trellis/testdata/trellis/.trellis/cli.yml
@@ -1,0 +1,2 @@
+open:
+  sentry: https://myapp.sentry.io

--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -263,7 +263,7 @@ func (t *Trellis) LoadCliConfig() *CliConfig {
 	}
 
 	if err == nil {
-		if err = yaml.Unmarshal(configYaml, &config); err != nil {
+		if err = yaml.UnmarshalStrict(configYaml, &config); err != nil {
 			log.Fatalln(err)
 		}
 	}

--- a/trellis/trellis_test.go
+++ b/trellis/trellis_test.go
@@ -302,8 +302,14 @@ func TestLoadProjectForProjects(t *testing.T) {
 		t.Errorf("expected %s to be %s", tp.Path, wd)
 	}
 
-	if !reflect.DeepEqual(tp.CliConfig, &CliConfig{}) {
-		t.Errorf("expected CliConfig to be an empty config")
+	expectedConfig := &CliConfig{
+		Open: map[string]string{
+			"sentry": "https://myapp.sentry.io",
+		},
+	}
+
+	if !reflect.DeepEqual(tp.CliConfig, expectedConfig) {
+		t.Errorf("expected config not equal")
 	}
 
 	expectedEnvNames := []string{"development", "production", "valet-link"}


### PR DESCRIPTION
Fixes #76 

`trellis open` is a way to easily open user-defined project specific "shortcuts" (usually URLs).

By default it opens the main site's canonical development URL in your default web browser. Any additional shortcuts can be defined in the CLI config in `.trellis/cli.yml` as a simple map of name to value.

For example:

```yaml
open:
  sentry: https://myapp.sentry.io
```