### PR TITLE
Add verbose option for Ansible commands

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -23,6 +23,7 @@ type DeployCommand struct {
 	extraVars string
 	Trellis   *trellis.Trellis
 	playbook  PlaybookRunner
+	verbose   bool
 }
 
 func (c *DeployCommand) init() {
@@ -30,6 +31,7 @@ func (c *DeployCommand) init() {
 	c.flags.Usage = func() { c.UI.Info(c.Help()) }
 	c.flags.StringVar(&c.branch, "branch", "", "Optional git branch to deploy which overrides the branch set in your site config (default: master)")
 	c.flags.StringVar(&c.extraVars, "extra-vars", "", "Additional variables which are passed through to Ansible as 'extra-vars'")
+	c.flags.BoolVar(&c.verbose, "verbose", false, "Enable Ansible's verbose mode")
 }
 
 func (c *DeployCommand) Run(args []string) int {
@@ -71,6 +73,10 @@ func (c *DeployCommand) Run(args []string) int {
 	vars := []string{
 		fmt.Sprintf("env=%s", environment),
 		fmt.Sprintf("site=%s", siteName),
+	}
+
+	if c.verbose {
+		vars = append(vars, "-vvvv")
 	}
 
 	if c.branch != "" {
@@ -120,6 +126,7 @@ Arguments:
 Options:
       --branch      Optional git branch to deploy which overrides the branch set in your site config (default: master)
       --extra-vars  (multiple) set additional variables as key=value or YAML/JSON, if filename prepend with @
+      --verbose     Enable Ansible's verbose mode
   -h, --help        show this help
 `
 
@@ -134,5 +141,6 @@ func (c *DeployCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
 		"--branch":     complete.PredictNothing,
 		"--extra-vars": complete.PredictNothing,
+		"--verbose":    complete.PredictNothing,
 	}
 }

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -119,6 +119,12 @@ func TestDeployRun(t *testing.T) {
 			"ansible-playbook deploy.yml -e env=development site=example.com branch=feature-123",
 			0,
 		},
+		{
+			"with_verbose",
+			[]string{"--verbose", "development"},
+			"ansible-playbook deploy.yml -e env=development site=example.com -vvvv",
+			0,
+		},
 	}
 
 	for _, tc := range cases {

--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -26,13 +26,15 @@ type ProvisionCommand struct {
 	tags      string
 	Trellis   *trellis.Trellis
 	playbook  PlaybookRunner
+	verbose   bool
 }
 
 func (c *ProvisionCommand) init() {
 	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
 	c.flags.Usage = func() { c.UI.Info(c.Help()) }
-	c.flags.StringVar(&c.tags, "tags", "", "only run roles and tasks tagged with these values")
 	c.flags.StringVar(&c.extraVars, "extra-vars", "", "Additional variables which are passed through to Ansible as 'extra-vars'")
+	c.flags.StringVar(&c.tags, "tags", "", "only run roles and tasks tagged with these values")
+	c.flags.BoolVar(&c.verbose, "verbose", false, "Enable Ansible's verbose mode")
 }
 
 func (c *ProvisionCommand) Run(args []string) int {
@@ -78,6 +80,10 @@ func (c *ProvisionCommand) Run(args []string) int {
 	playbookArgs := []string{"-e", vars}
 	if c.tags != "" {
 		playbookArgs = append(playbookArgs, "--tags", c.tags)
+	}
+
+	if c.verbose {
+		playbookArgs = append(playbookArgs, "-vvvv")
 	}
 
 	var playbookFile string = "server.yml"
@@ -133,6 +139,7 @@ Arguments:
 Options:
       --extra-vars  (multiple) set additional variables as key=value or YAML/JSON, if filename prepend with @
       --tags        (multiple) only run roles and tasks tagged with these values
+      --verbose     Enable Ansible's verbose mode
   -h, --help        show this help
 `
 
@@ -147,5 +154,6 @@ func (c *ProvisionCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
 		"--extra-vars": complete.PredictNothing,
 		"--tags":       complete.PredictNothing,
+		"--verbose":    complete.PredictNothing,
 	}
 }

--- a/cmd/provision_test.go
+++ b/cmd/provision_test.go
@@ -105,6 +105,12 @@ func TestProvisionRun(t *testing.T) {
 			"ansible-playbook dev.yml -e env=development k=v foo=bar",
 			0,
 		},
+		{
+			"with_verbose",
+			[]string{"--verbose", "development"},
+			"ansible-playbook dev.yml -e env=development -vvvv",
+			0,
+		},
 	}
 
 	for _, tc := range cases {

--- a/cmd/rollback_test.go
+++ b/cmd/rollback_test.go
@@ -113,6 +113,12 @@ func TestRollbackRun(t *testing.T) {
 			"ansible-playbook rollback.yml -e env=development site=example.com release=123",
 			0,
 		},
+		{
+			"with_verbose",
+			[]string{"--verbose", "development", "example.com"},
+			"ansible-playbook rollback.yml -e env=development site=example.com -vvvv",
+			0,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Fixes #230

`--verbose` translates to Ansible's full verbose mode of `-vvvv`