### PR TITLE
Add force option to init

### DIFF
--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -36,7 +36,7 @@ func TestInitRunValidations(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
 			trellis := trellis.NewMockTrellis(tc.projectDetected)
-			initCommand := &InitCommand{ui, trellis}
+			initCommand := NewInitCommand(ui, trellis)
 
 			code := initCommand.Run(tc.args)
 

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -121,7 +121,7 @@ func (c *NewCommand) Run(args []string) int {
 	}
 
 	if !c.skipVirtualenv {
-		initCommand := &InitCommand{UI: c.UI, Trellis: c.trellis}
+		initCommand := NewInitCommand(c.UI, c.trellis)
 		initCommand.Run([]string{})
 	}
 

--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func main() {
 			return &cmd.InfoCommand{UI: ui, Trellis: trellis}, nil
 		},
 		"init": func() (cli.Command, error) {
-			return &cmd.InitCommand{UI: ui, Trellis: trellis}, nil
+			return cmd.NewInitCommand(ui, trellis), nil
 		},
 		"new": func() (cli.Command, error) {
 			return cmd.NewNewCommand(ui, trellis, c.Version), nil


### PR DESCRIPTION
`--force` deletes the existing virtualenv first instead of just running `pip install`.