### PR TITLE
Add key generate command

### DIFF
--- a/cmd/key_generate.go
+++ b/cmd/key_generate.go
@@ -1,0 +1,278 @@
+package cmd
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/manifoldco/promptui"
+	"github.com/mitchellh/cli"
+	"github.com/mitchellh/go-homedir"
+	"github.com/posener/complete"
+	"github.com/roots/trellis-cli/trellis"
+)
+
+const secretName = "TRELLIS_DEPLOY_SSH_PRIVATE_KEY"
+const deployKeyName = "Trellis deploy"
+
+func NewKeyGenerateCommand(ui cli.Ui, trellis *trellis.Trellis) *KeyGenerateCommand {
+	c := &KeyGenerateCommand{UI: ui, Trellis: trellis}
+	c.init()
+	return c
+}
+
+type KeyGenerateCommand struct {
+	UI           cli.Ui
+	Trellis      *trellis.Trellis
+	flags        *flag.FlagSet
+	keyName      string
+	noGithub     bool
+	path         string
+	provisionEnv string
+}
+
+func (c *KeyGenerateCommand) init() {
+	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+	c.flags.Usage = func() { c.UI.Info(c.Help()) }
+	c.flags.BoolVar(&c.noGithub, "no-github", false, "Skips creating a GitHub secret and deploy key")
+	c.flags.StringVar(&c.keyName, "key-name", "", "Name of SSH key (Default: trellis_<site_name>_ed25519).")
+	c.flags.StringVar(&c.path, "path", "", "Path of private key (Default: $HOME/.ssh)")
+	c.flags.StringVar(&c.provisionEnv, "provision", "", "Environment to provision after key is generated")
+}
+
+func (c *KeyGenerateCommand) Run(args []string) int {
+	if err := c.Trellis.LoadProject(); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	if err := c.flags.Parse(args); err != nil {
+		return 1
+	}
+
+	args = c.flags.Args()
+
+	commandArgumentValidator := &CommandArgumentValidator{required: 0, optional: 0}
+	commandArgumentErr := commandArgumentValidator.validate(args)
+	if commandArgumentErr != nil {
+		c.UI.Error(commandArgumentErr.Error())
+		c.UI.Output(c.Help())
+		return 1
+	}
+
+	if c.keyName == "" {
+		siteName, siteNameErr := c.Trellis.FindSiteNameFromEnvironment("development", "")
+		if siteNameErr != nil {
+			c.UI.Error(siteNameErr.Error())
+			return 1
+		}
+
+		c.keyName = fmt.Sprintf("trellis_%s", strings.ReplaceAll(siteName, ".", "_"))
+	}
+
+	c.keyName = fmt.Sprintf("%s_ed25519", c.keyName)
+	publicKeyName := fmt.Sprintf("%s.pub", c.keyName)
+
+	if c.path == "" {
+		homePath, _ := homedir.Dir()
+		path := filepath.Join(homePath, ".ssh")
+		c.path = path
+	}
+
+	keyPath := filepath.Join(c.path, c.keyName)
+	publicKeyPath := filepath.Join(c.path, publicKeyName)
+	trellisPublicKeysPath := filepath.Join(c.Trellis.Path, "public_keys")
+	trellisPublicKeyPath := filepath.Join(trellisPublicKeysPath, publicKeyName)
+	os.Mkdir(trellisPublicKeysPath, os.ModePerm)
+
+	keyExists, _ := os.Stat(keyPath)
+	publicKeyExists, _ := os.Stat(trellisPublicKeyPath)
+
+	if keyExists != nil || publicKeyExists != nil {
+		c.UI.Error("Error: keys already exist. Delete them first if you want to re-generate a new key.")
+		c.UI.Error(fmt.Sprintf("Private key: %s", keyPath))
+		c.UI.Error(fmt.Sprintf("Public key: %s", trellisPublicKeyPath))
+		return 1
+	}
+
+	keygenArgs := []string{"-t", "ed25519", "-C", deployKeyName, "-f", keyPath, "-P", ""}
+	sshKeygen := exec.Command("ssh-keygen", keygenArgs...)
+	sshKeygen.Stdout = io.Discard
+	sshKeygen.Stderr = os.Stderr
+	err := sshKeygen.Run()
+
+	if err != nil {
+		c.UI.Error("Error: could not generate SSH key")
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	c.UI.Info(fmt.Sprintf("%s Generated SSH key [%s]", color.GreenString("[✓]"), keyPath))
+
+	err = os.Rename(publicKeyPath, trellisPublicKeyPath)
+
+	if err != nil {
+		c.UI.Error("Error: could not move public key")
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	c.UI.Info(fmt.Sprintf("%s Moved public key [%s]", color.GreenString("[✓]"), trellisPublicKeyPath))
+
+	if c.noGithub {
+		return 0
+	}
+
+	_, err = exec.LookPath("gh")
+	if err != nil {
+		c.UI.Error("Error: GitHub CLI not found")
+		c.UI.Error("gh command must be available to create a GitHub secret")
+		c.UI.Error("See https://cli.github.com")
+		return 1
+	}
+
+	privateKeyContent, err := ioutil.ReadFile(keyPath)
+	if err != nil {
+		c.UI.Error("Error: could not read SSH private key file")
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	ghArgs := []string{"secret", "set", secretName, "--body", string(privateKeyContent)}
+
+	ghSecret := exec.Command("gh", ghArgs...)
+	ghSecret.Stdout = io.Discard
+	ghSecret.Stderr = os.Stderr
+	err = ghSecret.Run()
+	if err != nil {
+		c.UI.Error("Error: could not create GitHub secret")
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	c.UI.Info(fmt.Sprintf("%s GitHub secret set [%s]", color.GreenString("[✓]"), secretName))
+
+	publicKeyContent, err := ioutil.ReadFile(trellisPublicKeyPath)
+	if err != nil {
+		c.UI.Error("Error: could not read SSH public key file")
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	publicKeyContent = bytes.TrimSuffix(publicKeyContent, []byte("\n"))
+
+	title := fmt.Sprintf("title=%s", deployKeyName)
+	key := fmt.Sprintf("key=%s", string(publicKeyContent))
+	ghApiArgs := []string{"api", "repos/{owner}/{repo}/keys", "-f", title, "-f", key, "-f", "read_only=true"}
+
+	ghApi := exec.Command("gh", ghApiArgs...)
+	ghApi.Stdout = io.Discard
+	ghApi.Stderr = os.Stderr
+	err = ghApi.Run()
+	if err != nil {
+		c.UI.Error("Error: could not create GitHub deploy key")
+		c.UI.Error(err.Error())
+		return 1
+	}
+	c.UI.Info(fmt.Sprintf("%s GitHub deploy key added [%s]\n", color.GreenString("[✓]"), deployKeyName))
+
+	if c.provisionEnv == "" {
+		c.UI.Info("The public key will not be usable until it's added to your server.")
+		prompt := promptui.Prompt{
+			Label:     "Provision now and apply the new public key",
+			IsConfirm: true,
+		}
+		_, err = prompt.Run()
+
+		if err != nil {
+			return 0
+		}
+
+		environments := c.Trellis.EnvironmentNames()
+
+		envPrompt := promptui.Select{
+			Label: "Select environment to provision",
+			Items: environments,
+			Size:  len(environments),
+		}
+
+		i, _, err := envPrompt.Run()
+
+		if err != nil {
+			c.UI.Error("Provision aborted")
+			return 0
+		}
+		c.provisionEnv = environments[i]
+	}
+
+	provisionCmd := NewProvisionCommand(c.UI, c.Trellis)
+	return provisionCmd.Run([]string{"--tags", "users", c.provisionEnv})
+}
+
+func (c *KeyGenerateCommand) Synopsis() string {
+	return "Generates an SSH key for Trellis deploys"
+}
+
+func (c *KeyGenerateCommand) Help() string {
+	helpText := `
+Usage: trellis key generate
+
+Generates an SSH key (using Ed25519 algorithm) for Trellis deploys with GitHub integration.
+
+* public key is created in 'trellis/public_keys' and added as a GitHub Deploy Key
+* private key is created in '$HOME/.ssh' and added as a GitHub Secret (so its accessible within GitHub Actions)
+
+This command relies on the GitHub CLI being installed and authenticated properly.
+See https://cli.github.com for more details and installation instructions.
+
+The GitHub repo used is detected automatically by the GitHub CLI.
+This command will fail if there's no GitHub repo or you don't have access to it.
+
+To skip the GitHub specific parts, use the --no-github option:
+
+  $ trellis key generate --no-github
+
+Specify a custom key name:
+
+  $ trellis key generate --name "my_key"
+
+Generate private key in a specific path:
+
+  $ trellis key generate --path ~/my_keys
+
+Options:
+      --name       Name of SSH key (Default: trellis_<site_name>_ed25519)
+      --no-github  Skips creating a GitHub secret and deploy key
+      --path       Path for private key (Default: $HOME/.ssh)
+      --provision  Name of environment to provision after key is generated
+  -h, --help       show this help
+`
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *KeyGenerateCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *KeyGenerateCommand) AutocompleteFlags() complete.Flags {
+	var environmentNames []string
+
+	if err := c.Trellis.LoadProject(); err == nil {
+		environmentNames = c.Trellis.EnvironmentNames()
+	}
+
+	return complete.Flags{
+		"--name":      complete.PredictNothing,
+		"--no-github": complete.PredictNothing,
+		"--path":      complete.PredictDirs(""),
+		"--provision": complete.PredictSet(environmentNames...),
+	}
+}

--- a/cmd/key_generate_test.go
+++ b/cmd/key_generate_test.go
@@ -1,0 +1,149 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/cli"
+	"github.com/roots/trellis-cli/trellis"
+)
+
+func TestKeyGenerateRunValidations(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
+
+	cases := []struct {
+		name            string
+		projectDetected bool
+		args            []string
+		out             string
+		code            int
+	}{
+		{
+			"no_project",
+			false,
+			nil,
+			"No Trellis project detected",
+			1,
+		},
+		{
+			"too_many_args",
+			true,
+			[]string{"foo"},
+			"Error: too many arguments",
+			1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ui := cli.NewMockUi()
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
+			keyGenerateCommand := NewKeyGenerateCommand(ui, trellis)
+
+			code := keyGenerateCommand.Run(tc.args)
+
+			if code != tc.code {
+				t.Errorf("expected code %d to be %d", code, tc.code)
+			}
+
+			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+
+			if !strings.Contains(combined, tc.out) {
+				t.Errorf("expected output %q to contain %q", combined, tc.out)
+			}
+		})
+	}
+}
+
+func TestKeyGenerateNewKey(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
+	trellis := trellis.NewTrellis()
+
+	tmpDir, _ := ioutil.TempDir("", "key_generate_test")
+	defer os.RemoveAll(tmpDir)
+
+	ui := cli.NewMockUi()
+	keyGenerateCommand := NewKeyGenerateCommand(ui, trellis)
+
+	code := keyGenerateCommand.Run([]string{"--path", tmpDir, "--no-github"})
+
+	if code != 0 {
+		t.Errorf("expected code %d to be %d", code, 0)
+	}
+
+	combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+	expected := fmt.Sprintf("Generated SSH key [%s]", filepath.Join(tmpDir, "trellis_example_com_ed25519"))
+
+	if !strings.Contains(combined, expected) {
+		t.Errorf("expected output %q to contain %q", combined, expected)
+	}
+
+	expected = fmt.Sprintf("Moved public key [%s]", filepath.Join(trellis.Path, "public_keys", "trellis_example_com_ed25519.pub"))
+
+	if !strings.Contains(combined, expected) {
+		t.Errorf("expected output %q to contain %q", combined, expected)
+	}
+}
+
+func TestKeyGenerateExistingPrivateKey(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
+	trellis := trellis.NewTrellis()
+
+	tmpDir, _ := ioutil.TempDir("", "key_generate_test")
+	defer os.RemoveAll(tmpDir)
+
+	privateKeyPath := filepath.Join(tmpDir, "trellis_example_com_ed25519")
+	ioutil.WriteFile(privateKeyPath, []byte{}, 0666)
+
+	ui := cli.NewMockUi()
+	keyGenerateCommand := NewKeyGenerateCommand(ui, trellis)
+
+	code := keyGenerateCommand.Run([]string{"--path", tmpDir, "--no-github"})
+
+	if code != 1 {
+		t.Errorf("expected code %d to be %d", code, 1)
+	}
+
+	combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+	expected := "keys already exist."
+
+	if !strings.Contains(combined, expected) {
+		t.Errorf("expected output %q to contain %q", combined, expected)
+	}
+}
+
+func TestKeyGenerateExistingPublicKey(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
+	trellis := trellis.NewTrellis()
+
+	tmpDir, _ := ioutil.TempDir("", "key_generate_test")
+	defer os.RemoveAll(tmpDir)
+
+	os.Mkdir(filepath.Join(trellis.Path, "public_keys"), os.ModePerm)
+	publicKeyPath := filepath.Join(trellis.Path, "public_keys", "trellis_example_com_ed25519.pub")
+	err := ioutil.WriteFile(publicKeyPath, []byte{}, 0666)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ui := cli.NewMockUi()
+	keyGenerateCommand := NewKeyGenerateCommand(ui, trellis)
+
+	code := keyGenerateCommand.Run([]string{"--path", tmpDir, "--no-github"})
+
+	if code != 1 {
+		t.Errorf("expected code %d to be %d", code, 1)
+	}
+
+	combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+	expected := "keys already exist."
+
+	if !strings.Contains(combined, expected) {
+		t.Errorf("expected output %q to contain %q", combined, expected)
+	}
+}

--- a/cmd/spinner.go
+++ b/cmd/spinner.go
@@ -23,10 +23,10 @@ func NewSpinner(config SpinnerCfg) *yacspin.Spinner {
 		Suffix:            " ",
 		Message:           config.Message,
 		SuffixAutoColon:   false,
-		StopCharacter:     "✓",
+		StopCharacter:     "[✓]",
 		StopColors:        []string{"fgGreen"},
 		StopMessage:       config.StopMessage,
-		StopFailCharacter: "✘",
+		StopFailCharacter: "[✘]",
 		StopFailColors:    []string{"fgRed"},
 		StopFailMessage:   config.FailMessage,
 	}

--- a/main.go
+++ b/main.go
@@ -104,6 +104,15 @@ func main() {
 		"init": func() (cli.Command, error) {
 			return cmd.NewInitCommand(ui, trellis), nil
 		},
+		"key": func() (cli.Command, error) {
+			return &cmd.NamespaceCommand{
+				HelpText:     "Usage: trellis key <subcommand> [<args>]",
+				SynopsisText: "Commands for managing SSH keys",
+			}, nil
+		},
+		"key generate": func() (cli.Command, error) {
+			return cmd.NewKeyGenerateCommand(ui, trellis), nil
+		},
 		"new": func() (cli.Command, error) {
 			return cmd.NewNewCommand(ui, trellis, c.Version), nil
 		},


### PR DESCRIPTION
`trellis key generate` does the following:

1. creates a public/private SSH keypair using the Ed25519 algorithm
2. private key is created in $HOME/.ssh (by default)
3. public key is moved to `trellis/public_keys`
4. a GitHub secret is created for the private key on the current repo
5. a GitHub deploy key is created for the public key on the current repo
6. optionally provisions the server to ensure the public key is added and active

This command helps to setup a deployment process from a CI/CD platform like GitHub Actions which requires a deploy specific SSH key.

To accomplish this, it relies on the GitHub CLI being installed to take care of all the GitHub integration.

Output:
<img width="1032" alt="image" src="https://user-images.githubusercontent.com/295605/147787744-0dee0599-bd77-4521-ab96-9424a9e72e7e.png">