### PR TITLE
Improve positional argument autocomplete when flags present

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -138,7 +138,7 @@ Options:
 }
 
 func (c *DeployCommand) AutocompleteArgs() complete.Predictor {
-	return c.Trellis.AutocompleteSite()
+	return c.Trellis.AutocompleteSite(c.flags)
 }
 
 func (c *DeployCommand) AutocompleteFlags() complete.Flags {

--- a/cmd/droplet_create.go
+++ b/cmd/droplet_create.go
@@ -436,7 +436,7 @@ Options:
 }
 
 func (c *DropletCreateCommand) AutocompleteArgs() complete.Predictor {
-	return c.Trellis.PredictEnvironment()
+	return c.Trellis.PredictEnvironment(c.flags)
 }
 
 func (c *DropletCreateCommand) AutocompleteFlags() complete.Flags {
@@ -444,6 +444,6 @@ func (c *DropletCreateCommand) AutocompleteFlags() complete.Flags {
 		"--region":          complete.PredictNothing,
 		"--size":            complete.PredictNothing,
 		"--skip--provision": complete.PredictNothing,
-		"--ssh-key":         complete.PredictFiles("*"),
+		"--ssh-key":         complete.PredictFiles("*.pub"),
 	}
 }

--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -147,7 +147,7 @@ Options:
 }
 
 func (c *ProvisionCommand) AutocompleteArgs() complete.Predictor {
-	return c.Trellis.AutocompleteEnvironment()
+	return c.Trellis.AutocompleteEnvironment(c.flags)
 }
 
 func (c *ProvisionCommand) AutocompleteFlags() complete.Flags {

--- a/cmd/rollback.go
+++ b/cmd/rollback.go
@@ -126,7 +126,7 @@ Options:
 }
 
 func (c *RollbackCommand) AutocompleteArgs() complete.Predictor {
-	return c.Trellis.AutocompleteSite()
+	return c.Trellis.AutocompleteSite(c.flags)
 }
 
 func (c *RollbackCommand) AutocompleteFlags() complete.Flags {

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"flag"
 	"fmt"
 	"strings"
 
@@ -105,7 +106,7 @@ Options:
 }
 
 func (c *SshCommand) AutocompleteArgs() complete.Predictor {
-	return c.Trellis.AutocompleteSite()
+	return c.Trellis.AutocompleteSite(flag.NewFlagSet("", flag.ContinueOnError))
 }
 
 func (c *SshCommand) AutocompleteFlags() complete.Flags {

--- a/cmd/vault_decrypt.go
+++ b/cmd/vault_decrypt.go
@@ -130,7 +130,7 @@ Options:
 }
 
 func (c *VaultDecryptCommand) AutocompleteArgs() complete.Predictor {
-	return c.Trellis.AutocompleteEnvironment()
+	return c.Trellis.AutocompleteEnvironment(c.flags)
 }
 
 func (c *VaultDecryptCommand) AutocompleteFlags() complete.Flags {

--- a/cmd/vault_encrypt.go
+++ b/cmd/vault_encrypt.go
@@ -164,7 +164,7 @@ Options:
 }
 
 func (c *VaultEncryptCommand) AutocompleteArgs() complete.Predictor {
-	return c.Trellis.AutocompleteEnvironment()
+	return c.Trellis.AutocompleteEnvironment(c.flags)
 }
 
 func (c *VaultEncryptCommand) AutocompleteFlags() complete.Flags {

--- a/cmd/vault_view.go
+++ b/cmd/vault_view.go
@@ -110,7 +110,7 @@ Options:
 }
 
 func (c *VaultViewCommand) AutocompleteArgs() complete.Predictor {
-	return c.Trellis.AutocompleteEnvironment()
+	return c.Trellis.AutocompleteEnvironment(c.flags)
 }
 
 func (c *VaultViewCommand) AutocompleteFlags() complete.Flags {

--- a/trellis/complete.go
+++ b/trellis/complete.go
@@ -1,24 +1,30 @@
 package trellis
 
 import (
+	"flag"
 	"github.com/posener/complete"
+	"io"
 )
 
-func (t *Trellis) AutocompleteSite() complete.Predictor {
-	return t.PredictSite()
+func (t *Trellis) AutocompleteSite(flags *flag.FlagSet) complete.Predictor {
+	return t.PredictSite(flags)
 }
 
-func (t *Trellis) AutocompleteEnvironment() complete.Predictor {
-	return t.PredictEnvironment()
+func (t *Trellis) AutocompleteEnvironment(flags *flag.FlagSet) complete.Predictor {
+	return t.PredictEnvironment(flags)
 }
 
-func (t *Trellis) PredictSite() complete.PredictFunc {
+func (t *Trellis) PredictSite(flags *flag.FlagSet) complete.PredictFunc {
 	return func(args complete.Args) []string {
 		if err := t.LoadProject(); err != nil {
 			return []string{}
 		}
 
-		switch len(args.Completed) {
+		flags.SetOutput(io.Discard)
+		flags.Parse(args.Completed)
+		cmdArgs := flags.Args()
+
+		switch len(cmdArgs) {
 		case 0:
 			return t.EnvironmentNames()
 		case 1:
@@ -29,13 +35,17 @@ func (t *Trellis) PredictSite() complete.PredictFunc {
 	}
 }
 
-func (t *Trellis) PredictEnvironment() complete.PredictFunc {
+func (t *Trellis) PredictEnvironment(flags *flag.FlagSet) complete.PredictFunc {
 	return func(args complete.Args) []string {
 		if err := t.LoadProject(); err != nil {
 			return []string{}
 		}
 
-		switch len(args.Completed) {
+		flags.SetOutput(io.Discard)
+		flags.Parse(args.Completed)
+		cmdArgs := flags.Args()
+
+		switch len(cmdArgs) {
 		case 0:
 			return t.EnvironmentNames()
 		default:


### PR DESCRIPTION
Previously autocomplete would not work for positional arguments if any flags/options were present.

Example: `trellis provision --verbose pro`

The environment argument ("prod") would not be autocompleted. This was because of the predict functions which would act on `args.Completed`, and unfortunately, the complete package _includes_ flags in that array.

This solution passes in the command's flag set and uses that to parse the args. Now the predict functions acts on the positional args only, not the full set of completed args.

Opened an upstream issue since having to do this workaround seems complex and unnecessary: https://github.com/posener/complete/issues/146