### PR TITLE
Give python3 precedence for venv

### DIFF
--- a/trellis/virtualenv.go
+++ b/trellis/virtualenv.go
@@ -110,14 +110,14 @@ func (v *Virtualenv) Install() string {
 }
 
 func (v *Virtualenv) Installed() (ok bool, cmd *exec.Cmd) {
-	path, err := exec.LookPath("virtualenv")
-	if err == nil {
-		return true, exec.Command(path)
-	}
-
-	path, err = exec.LookPath("python3")
+	path, err := exec.LookPath("python3")
 	if err == nil {
 		return true, exec.Command(path, "-m", "venv")
+	}
+
+	path, err = exec.LookPath("virtualenv")
+	if err == nil {
+		return true, exec.Command(path)
 	}
 
 	localVenvPath := filepath.Join(v.LocalPath(), "virtualenv.py")


### PR DESCRIPTION
Previously `virtualenv` was used if found. Instead we'll default to `python3` if available to ensure that Python 3 is used whenever possible over Python 2.