### PR TITLE
Improve init and virtual error messages

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -122,7 +122,11 @@ func (c *NewCommand) Run(args []string) int {
 
 	if !c.skipVirtualenv {
 		initCommand := NewInitCommand(c.UI, c.trellis)
-		initCommand.Run([]string{})
+		code := initCommand.Run([]string{})
+
+		if code != 0 {
+			return 1
+		}
 	}
 
 	// Update default configs

--- a/trellis/virtualenv.go
+++ b/trellis/virtualenv.go
@@ -69,6 +69,10 @@ func (v *Virtualenv) Deactivate() {
 	os.Setenv(PathEnvName, v.OldPath)
 }
 
+func (v *Virtualenv) Delete() error {
+	return os.RemoveAll(v.Path)
+}
+
 func (v *Virtualenv) LocalPath() string {
 	configHome := os.Getenv("XDG_CONFIG_HOME")
 
@@ -96,17 +100,17 @@ func (v *Virtualenv) Initialized() bool {
 	return true
 }
 
-func (v *Virtualenv) Install() string {
+func (v *Virtualenv) Install() (installPath string, err error) {
 	localPath := v.LocalPath()
 	configDir := filepath.Dir(localPath)
 
-	if _, err := os.Stat(configDir); os.IsNotExist(err) {
+	if _, err = os.Stat(configDir); os.IsNotExist(err) {
 		if err = os.MkdirAll(configDir, 0755); err != nil {
-			log.Fatal(err)
+			return "", err
 		}
 	}
 
-	return github.DownloadRelease("pypa/virtualenv", "latest", os.TempDir(), localPath)
+	return github.DownloadRelease("pypa/virtualenv", "latest", os.TempDir(), localPath), nil
 }
 
 func (v *Virtualenv) Installed() (ok bool, cmd *exec.Cmd) {


### PR DESCRIPTION
Adds more verbose and actionable error output when trellis-cli either can't install virtual, or more commonly, fails to create a virtual environment. The command used to create the venv is also included now for better debugging.

This also prevents `new` from continuing to create a new project if the initialization process fails. If the venv wasn't created successfully, dependencies won't be installed which will just lead to more errors (and more confusion).

Example output before:
```plain
Creating virtualenv in /mnt/d/Projects/mytest.test/trellis/.trellis/virtualenv
Error creating virtualenv: exit status 1
ERROR! Unexpected Exception, this is probably a bug: cannot import name 'CollectionRequirement' from 'ansible.galaxy.collection' (/home/phxitm/.local/lib/python3.8/site-packages/ansible/galaxy/collection/__init__.py)

Error running ansible-galaxy: exit status 250

mytest.test project created with versions:
  Trellis v1.11.0
  Bedrock v1.18.0
```

Because the virtualenv couldn't be created, the wrong Ansible version is used which leads to cascading errors yet the project is still created. Now they'll be a single error with better output and the project will fail.