### PR TITLE
Remove virtualenv install fallback

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -56,31 +56,15 @@ func (c *InitCommand) Run(args []string) int {
 		return 1
 	}
 
-	c.UI.Info("Initializing project\n")
+	c.UI.Info("Initializing project...\n")
 	ok, virtualenvCmd := c.Trellis.Virtualenv.Installed()
 
 	if !ok {
-		c.UI.Info("virtualenv not found")
-		spinner := NewSpinner(
-			SpinnerCfg{
-				Message:     "Installing virtualenv",
-				FailMessage: "Error installing virtualenv",
-			},
-		)
-		spinner.Start()
-		_, err := c.Trellis.Virtualenv.Install()
-		spinner.Stop()
-
-		c.UI.Error(err.Error())
+		c.UI.Error("virtualenv not found. trellis-cli looked for two options:")
+		c.UI.Error("  1. python3's built-in `venv` module")
+		c.UI.Error("  2. standalone `virtualenv` command")
 		c.UI.Error("")
-		c.UI.Error("Project initialization failed due to the error above.")
-		c.UI.Error("")
-		c.UI.Error("trellis-cli attempted to install virtualenv as a fallback but failed.")
-		c.UI.Error("Without virtualenv, a Python virtual environment cannot be created and the required dependencies (eg: Ansible) can't be installed either.")
-		c.UI.Error("")
-		c.UI.Error("There are two options:")
-		c.UI.Error("  1. Ensure Python 3 is installed and the `python3` command works. trellis-cli will use python3's built-in venv feature.")
-		c.UI.Error(fmt.Sprintf("  2. Disable trellis-cli's virtual env feature by setting this env variable: export %s=false", trellis.TrellisVenvEnvName))
+		virtualenvError(c.UI)
 		return 1
 	}
 
@@ -123,13 +107,7 @@ func (c *InitCommand) Run(args []string) int {
 			c.UI.Error("trellis-cli tried to create a virtual environment but failed.")
 			c.UI.Error(fmt.Sprintf("  => %s", virtualenvCmd.String()))
 			c.UI.Error("")
-			c.UI.Error("Without a Python virtual environment the required dependencies (eg: Ansible) can't be installed.")
-			c.UI.Error("")
-			c.UI.Error("There are two options:")
-			c.UI.Error("  1. Ensure Python 3 is installed and the `python3` command works. trellis-cli will use python3's built-in venv feature.")
-			c.UI.Error(fmt.Sprintf("  2. Disable trellis-cli's virtual env feature by setting this env variable: export %s=false", trellis.TrellisVenvEnvName))
-			c.UI.Error("")
-			c.UI.Error("This could also be a bug in trellis-cli. Please create an issue at https://github.com/roots/trellis-cli and include the output above.")
+			virtualenvError(c.UI)
 			return 1
 		}
 
@@ -198,4 +176,15 @@ Options:
 `
 
 	return strings.TrimSpace(helpText)
+}
+
+func virtualenvError(ui cli.Ui) {
+	ui.Error("Without virtualenv, a Python virtual environment cannot be created and the required dependencies (eg: Ansible) can't be installed either.")
+	ui.Error("")
+	ui.Error("There are two options:")
+	ui.Error("  1. Ensure Python 3 is installed and the `python3` command works. trellis-cli will use python3's built-in venv feature.")
+	ui.Error("     Ubuntu/Debian users (including Windows WSL): venv is not built-in, to install it run `sudo apt-get install python3-pip python3-venv`")
+	ui.Error("")
+	ui.Error("  2. Disable trellis-cli's virtual env feature, and manage dependencies manually, by setting this env variable:")
+	ui.Error(fmt.Sprintf("     export %s=false", trellis.TrellisVenvEnvName))
 }


### PR DESCRIPTION
Previously trellis-cli tried to fallback to installing virtualenv if no other method was found. Turns out this was completely broken!

Since it's a complicated feature to offer, and users should really install it manually themselves, this feature is being removed entirely for now.

This also improves the existing `python3 -m venv` detection feature by adding an additional check to make sure it actually exists. This catches an edge case for Ubuntu/Debian/WSL users because their python3 package does not include venv.

Now those users will be shown an error letting them know what needs to be done.