### PR TITLE
Fix ssh-keyscan error handling in `key generate` command

### DIFF
--- a/cmd/key_generate_test.go
+++ b/cmd/key_generate_test.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/mitchellh/cli"
+	"github.com/roots/trellis-cli/command"
 	"github.com/roots/trellis-cli/trellis"
 )
 
@@ -149,6 +151,40 @@ func TestKeyGenerateExistingPublicKey(t *testing.T) {
 	}
 }
 
+func TestKeyGenerateKeyscan(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
+	trellis := trellis.NewTrellis()
+
+	tmpDir, _ := ioutil.TempDir("", "key_generate_test")
+	defer os.RemoveAll(tmpDir)
+
+	// fake gh binary to satisfy ok.LookPath
+	ghPath := filepath.Join(tmpDir, "gh")
+	os.OpenFile(ghPath, os.O_CREATE, 0555)
+	path := os.Getenv("PATH")
+	os.Setenv("PATH", fmt.Sprintf("PATH=%s:%s", path, tmpDir))
+
+	mockExecCommand := func(command string, args []string) *exec.Cmd {
+		cs := []string{"-test.run=TestKeyGenerateHelperProcess", "--", command}
+		cs = append(cs, args...)
+		cmd := exec.Command(os.Args[0], cs...)
+		cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1", fmt.Sprintf("GO_TEST_HELPER_TMP_PATH=%s", tmpDir)}
+		return cmd
+	}
+
+	command.Mock(mockExecCommand)
+	defer command.Restore()
+
+	ui := cli.NewMockUi()
+	keyGenerateCommand := NewKeyGenerateCommand(ui, trellis)
+
+	code := keyGenerateCommand.Run([]string{"--path", tmpDir})
+
+	if code != 0 {
+		t.Errorf("expected code %d to be %d", code, 0)
+	}
+}
+
 func TestParseAnsibleHosts(t *testing.T) {
 	output := `
   hosts (3):
@@ -162,10 +198,49 @@ func TestParseAnsibleHosts(t *testing.T) {
 	expectedHosts := []string{
 		"192.168.56.5",
 		"192.168.56.10",
-		"your_server_hostname",
 	}
 
 	if !reflect.DeepEqual(hosts, expectedHosts) {
 		t.Errorf("expected hosts %q to equal %q", hosts, expectedHosts)
+	}
+}
+
+func TestKeyGenerateHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	switch os.Args[3] {
+	case "ansible":
+		hosts := `
+good_host
+bad_host
+your_server_hostname
+`
+		fmt.Fprintf(os.Stdout, hosts)
+		os.Exit(0)
+	case "ssh-keyscan":
+		switch os.Args[len(os.Args)-1] {
+		case "good_host":
+			// return fake hash for a good host
+			host := "|1|5XBUprxMy6abCgLQkQ0= ssh-ed25519 AAAAC3NzaC1lZYqEOf"
+			fmt.Fprintf(os.Stdout, host)
+			os.Exit(0)
+		case "bad_host":
+			// simulate error for a bad host
+			os.Exit(1)
+		}
+	case "ssh-keygen":
+		tmpDir := os.Getenv("GO_TEST_HELPER_TMP_PATH")
+		path := filepath.Join(tmpDir, "trellis_example_com_ed25519.pub")
+		os.OpenFile(path, os.O_CREATE, 0644)
+		path = filepath.Join(tmpDir, "trellis_example_com_ed25519")
+		os.OpenFile(path, os.O_CREATE, 0644)
+		os.Exit(0)
+	case "gh":
+		// make all gh commands succeed. No output needed
+		os.Exit(0)
+	default:
+		t.Fatalf("unexpected command %s", os.Args[3])
 	}
 }


### PR DESCRIPTION
The last step in the `key generate` command is using `ssh-keyscan` to set the known hosts. It was fairly broken and the error handling didn't help to identify the problem.

Instead of scanning all hosts from a single command, this runs once per host to ensure one bad host doesn't prevent the good ones from succeeding. The error message also includes the hosts it tried to scan.

Finally, the ansible command to gather hosts has been improved by omitting development hosts.