### PR TITLE
Improve failure modes during new project creation

### DIFF
--- a/cmd/galaxy_install.go
+++ b/cmd/galaxy_install.go
@@ -62,8 +62,9 @@ func (c *GalaxyInstallCommand) Run(args []string) int {
 	err := galaxyInstall.Run()
 
 	if err != nil {
+		c.UI.Error("Error while installing Ansible Galaxy roles:")
 		c.UI.Error(mockUi.ErrorWriter.String())
-		c.UI.Error(fmt.Sprintf("Error running ansible-galaxy: %s", err))
+		c.UI.Error("This may be a temporary network issue. Please try again.")
 		return 1
 	}
 
@@ -89,7 +90,8 @@ func (c *GalaxyInstallCommand) Run(args []string) int {
 		err = galaxyInstall.Run()
 
 		if err != nil {
-			c.UI.Error(fmt.Sprintf("Error running ansible-galaxy: %s", err))
+			c.UI.Error("Error while updating Ansible Galaxy roles:")
+			c.UI.Error("This may be a temporary network issue. Please try again.")
 			return 1
 		}
 	}

--- a/github/main_test.go
+++ b/github/main_test.go
@@ -56,10 +56,10 @@ func TestDownloadRelease(t *testing.T) {
 
 	const expectedVersion = "1.0.0"
 
-	version := DownloadRelease("roots/trellis", expectedVersion, tmpDir, filepath.Join(tmpDir, "test_release_dir"))
+	release, err := DownloadRelease("roots/trellis", expectedVersion, tmpDir, filepath.Join(tmpDir, "test_release_dir"))
 
-	if expectedVersion != version {
-		t.Errorf("expected version %s but got %s", expectedVersion, version)
+	if expectedVersion != release.Version {
+		t.Errorf("expected version %s but got %s", expectedVersion, release.Version)
 	}
 }
 


### PR DESCRIPTION
Fixes #262

This improves failure modes and error handling during the `new` command while creating a new project. Previously it was too easy for transient network failures to break a key part in the project creation process.
And even worse, the project would continue onto as is no failure happened.

Now every step has proper error handling that is checked, and in the case of a error, the process is stopped with a more helpful error message.