### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cmd/key_generate_test.go
+++ b/cmd/key_generate_test.go
@@ -66,8 +66,7 @@ func TestKeyGenerateNewKey(t *testing.T) {
 	defer trellis.LoadFixtureProject(t)()
 	trellis := trellis.NewTrellis()
 
-	tmpDir, _ := ioutil.TempDir("", "key_generate_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	ui := cli.NewMockUi()
 	keyGenerateCommand := NewKeyGenerateCommand(ui, trellis)
@@ -96,8 +95,7 @@ func TestKeyGenerateExistingPrivateKey(t *testing.T) {
 	defer trellis.LoadFixtureProject(t)()
 	trellis := trellis.NewTrellis()
 
-	tmpDir, _ := ioutil.TempDir("", "key_generate_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	privateKeyPath := filepath.Join(tmpDir, "trellis_example_com_ed25519")
 	ioutil.WriteFile(privateKeyPath, []byte{}, 0666)
@@ -123,8 +121,7 @@ func TestKeyGenerateExistingPublicKey(t *testing.T) {
 	defer trellis.LoadFixtureProject(t)()
 	trellis := trellis.NewTrellis()
 
-	tmpDir, _ := ioutil.TempDir("", "key_generate_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	os.Mkdir(filepath.Join(trellis.Path, "public_keys"), os.ModePerm)
 	publicKeyPath := filepath.Join(trellis.Path, "public_keys", "trellis_example_com_ed25519.pub")
@@ -155,8 +152,7 @@ func TestKeyGenerateKeyscan(t *testing.T) {
 	defer trellis.LoadFixtureProject(t)()
 	trellis := trellis.NewTrellis()
 
-	tmpDir, _ := ioutil.TempDir("", "key_generate_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	// fake gh binary to satisfy ok.LookPath
 	ghPath := filepath.Join(tmpDir, "gh")

--- a/github/main_test.go
+++ b/github/main_test.go
@@ -3,7 +3,6 @@ package github
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -28,8 +27,7 @@ func TestNewReleaseFromVersion(t *testing.T) {
 }
 
 func TestDownloadRelease(t *testing.T) {
-	tmpDir, _ := ioutil.TempDir("", "release_test")
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	os.Chdir(tmpDir)
 
 	var dir = "roots-trellis"

--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,16 +23,7 @@ func TestIntegrationForceNoPlugin(t *testing.T) {
 		t.Error(bin + " not exist")
 	}
 
-	tempDir, err := ioutil.TempDir(os.TempDir(), "test-cmd-plugins")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	// cleanup
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			panic(fmt.Errorf("unexpected cleanup error: %v", err))
-		}
-	}()
+	tempDir := t.TempDir()
 
 	file, err := os.Create(filepath.Join(tempDir, "trellis-abc"))
 	if err != nil {

--- a/plugin/finder_test.go
+++ b/plugin/finder_test.go
@@ -1,7 +1,6 @@
 package plugin
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -10,16 +9,7 @@ import (
 )
 
 func TestFind(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "test-cmd-plugins")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	// cleanup
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			panic(fmt.Errorf("unexpected cleanup error: %v", err))
-		}
-	}()
+	tempDir := t.TempDir()
 
 	createTempFile := func(name string, mode os.FileMode) (*os.File, error) {
 		file, err := os.Create(filepath.Join(tempDir, name))
@@ -168,16 +158,7 @@ func TestFind(t *testing.T) {
 }
 
 func TestIsExecutable(t *testing.T) {
-	tempDir, err := ioutil.TempDir(os.TempDir(), "test-cmd-plugins")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	// cleanup
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			panic(fmt.Errorf("unexpected cleanup error: %v", err))
-		}
-	}()
+	tempDir := t.TempDir()
 
 	createTempFile := func(mode os.FileMode) (*os.File, error) {
 		file, err := ioutil.TempFile(tempDir, "trellis-")

--- a/plugin/register_test.go
+++ b/plugin/register_test.go
@@ -1,8 +1,6 @@
 package plugin
 
 import (
-	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -33,16 +31,7 @@ func TestIntegrationPluginCommand(t *testing.T) {
 		t.Error(bin + " not exist")
 	}
 
-	tempDir, err := ioutil.TempDir(os.TempDir(), "test-cmd-plugins")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	// cleanup
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			panic(fmt.Errorf("unexpected cleanup error: %v", err))
-		}
-	}()
+	tempDir := t.TempDir()
 
 	file, err := os.Create(filepath.Join(tempDir, "trellis-spy-foo"))
 	if err != nil {
@@ -150,16 +139,7 @@ func TestIntegrationPluginListInHelpFunc(t *testing.T) {
 		t.Error(bin + " not exist")
 	}
 
-	tempDir, err := ioutil.TempDir(os.TempDir(), "test-cmd-plugins")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	// cleanup
-	defer func() {
-		if err := os.RemoveAll(tempDir); err != nil {
-			panic(fmt.Errorf("unexpected cleanup error: %v", err))
-		}
-	}()
+	tempDir := t.TempDir()
 
 	createTempFile := func(name string, mode os.FileMode) (*os.File, error) {
 		file, err := os.Create(filepath.Join(tempDir, name))

--- a/trellis/detector_test.go
+++ b/trellis/detector_test.go
@@ -10,8 +10,7 @@ import (
 const testDir = "tmp"
 
 func TestDetect(t *testing.T) {
-	testDir, _ := ioutil.TempDir("", "trellis")
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	devDir := filepath.Join(testDir, "group_vars", "development")
 
@@ -67,8 +66,7 @@ func TestDetect(t *testing.T) {
 }
 
 func TestDetectTrellisProjectStructure(t *testing.T) {
-	testDir, _ := ioutil.TempDir("", "trellis")
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	trellisDir := filepath.Join(testDir, "trellis")
 	siteDir := filepath.Join(testDir, "site")

--- a/trellis/trellis_test.go
+++ b/trellis/trellis_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestCreateConfigDir(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	configPath := dir + "/testing-trellis-create-config-dir"
 
 	trellis := Trellis{
@@ -260,13 +259,9 @@ func TestActivateProjectForProjects(t *testing.T) {
 }
 
 func TestActivateProjectForNonProjects(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "trellis")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	tempDir := t.TempDir()
 
 	defer TestChdir(t, tempDir)()
-	defer os.RemoveAll(tempDir)
 
 	tp := NewTrellis()
 

--- a/trellis/virtualenv_test.go
+++ b/trellis/virtualenv_test.go
@@ -3,7 +3,6 @@ package trellis
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -108,12 +107,7 @@ func TestDeactive(t *testing.T) {
 }
 
 func TestInitialized(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "trellis")
-	defer os.RemoveAll(tempDir)
-
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	tempDir := t.TempDir()
 
 	venv := NewVirtualenv(tempDir)
 
@@ -144,13 +138,7 @@ func TestInstalled(t *testing.T) {
 }
 
 func TestInstalledPython3WithEnsurepip(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "trellis")
-	defer os.RemoveAll(tempDir)
-
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
+	tempDir := t.TempDir()
 	defer testSetEnv("PATH", tempDir)()
 
 	pythonPath := filepath.Join(tempDir, "python3")
@@ -188,13 +176,7 @@ func TestInstalledPython3WithEnsurepip(t *testing.T) {
 }
 
 func TestInstalledPython3WithoutEnsurepip(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "trellis")
-	defer os.RemoveAll(tempDir)
-
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
+	tempDir := t.TempDir()
 	defer testSetEnv("PATH", tempDir)()
 
 	pythonPath := filepath.Join(tempDir, "python3")
@@ -225,13 +207,7 @@ func TestInstalledPython3WithoutEnsurepip(t *testing.T) {
 }
 
 func TestInstalledVirtualenv(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "trellis")
-	defer os.RemoveAll(tempDir)
-
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
+	tempDir := t.TempDir()
 	defer testSetEnv("PATH", tempDir)()
 
 	venvPath := filepath.Join(tempDir, "virtualenv")
@@ -306,8 +282,7 @@ next line
 }
 
 func TestUpdateBinShebangsNoSpaces(t *testing.T) {
-	dir, _ := ioutil.TempDir("", "shebangs-nospaces-")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	os.MkdirAll(filepath.Join(dir, "virtualenv", "bin"), 0755)
 
@@ -333,8 +308,7 @@ func TestUpdateBinShebangsNoSpaces(t *testing.T) {
 
 func TestUpdateBinShebangsWithSpaces(t *testing.T) {
 	t.SkipNow()
-	dir, _ := ioutil.TempDir("", "shebangs with spaces-")
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	os.MkdirAll(filepath.Join(dir, "virtualenv", "bin"), 0755)
 

--- a/update/main_test.go
+++ b/update/main_test.go
@@ -20,8 +20,7 @@ type Env struct {
 }
 
 func TestDoesNotCheckForUpdate(t *testing.T) {
-	cacheDir, _ := ioutil.TempDir("", "trellis_cache")
-	defer os.RemoveAll(cacheDir)
+	cacheDir := t.TempDir()
 
 	cases := []struct {
 		name          string
@@ -213,8 +212,7 @@ latest_release:
 	}
 
 	for _, tc := range cases {
-		cacheDir, _ := ioutil.TempDir("", "trellis_cache")
-		defer os.RemoveAll(cacheDir)
+		cacheDir := t.TempDir()
 
 		if tc.stateEntry != "" {
 			_ = ioutil.WriteFile(filepath.Join(cacheDir, "state.yml"), []byte(tc.stateEntry), 0600)


### PR DESCRIPTION
A small testing enhancement.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir