### PR TITLE
Readme: Bump go requirement to v1.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Supported commands so far:
 
 ## Development
 
-trellis-cli requires Go >= 1.13 (`brew install go` on macOS)
+trellis-cli requires Go >= 1.15 (`brew install go` on macOS)
 
 ```bash
 # Clone the repo


### PR DESCRIPTION
Because [`T.TempDir`](https://pkg.go.dev/testing#T.TempDir) used in #264 was added in go v1.15.

[ci skip]
