### PR TITLE
Use built-in testing.Setenv

### DIFF
--- a/cmd/key_generate_test.go
+++ b/cmd/key_generate_test.go
@@ -158,10 +158,7 @@ func TestKeyGenerateKeyscan(t *testing.T) {
 	ghPath := filepath.Join(tmpDir, "gh")
 	os.OpenFile(ghPath, os.O_CREATE, 0555)
 	path := os.Getenv("PATH")
-	os.Setenv("PATH", fmt.Sprintf("PATH=%s:%s", path, tmpDir))
-	defer func() {
-		os.Setenv("PATH", path)
-	}()
+	t.Setenv("PATH", fmt.Sprintf("PATH=%s:%s", path, tmpDir))
 
 	mockExecCommand := func(command string, args []string) *exec.Cmd {
 		cs := []string{"-test.run=TestKeyGenerateHelperProcess", "--", command}

--- a/cmd/venv_hook_test.go
+++ b/cmd/venv_hook_test.go
@@ -37,7 +37,7 @@ func TestVenvHookRunActivatesEnv(t *testing.T) {
 }
 
 func TestVenvHookRunDeactivatesEnv(t *testing.T) {
-	os.Setenv(trellis.OldPathEnvName, "foo")
+	t.Setenv(trellis.OldPathEnvName, "foo")
 
 	ui := cli.NewMockUi()
 	trellis := trellis.NewMockTrellis(false)

--- a/trellis/complete_test.go
+++ b/trellis/complete_test.go
@@ -134,7 +134,7 @@ func TestCompletionFunctions(t *testing.T) {
 // pressed in a shell to autocomplete a command.
 func testAutocomplete(t *testing.T, input string) func() {
 	// This env var is used to trigger autocomplete
-	os.Setenv(envComplete, input)
+	t.Setenv(envComplete, input)
 
 	// Change stdout/stderr since the autocompleter writes directly to them.
 	oldStdout := os.Stdout

--- a/trellis/virtualenv_test.go
+++ b/trellis/virtualenv_test.go
@@ -125,8 +125,8 @@ func TestInitialized(t *testing.T) {
 }
 
 func TestInstalled(t *testing.T) {
-	defer testSetEnv("PATH", "")()
-	defer testSetEnv("XDG_CONFIG_HOME", "none")()
+	t.Setenv("PATH", "")
+	t.Setenv("XDG_CONFIG_HOME", "none")
 
 	venv := NewVirtualenv("foo")
 
@@ -139,7 +139,7 @@ func TestInstalled(t *testing.T) {
 
 func TestInstalledPython3WithEnsurepip(t *testing.T) {
 	tempDir := t.TempDir()
-	defer testSetEnv("PATH", tempDir)()
+	t.Setenv("PATH", tempDir)
 
 	pythonPath := filepath.Join(tempDir, "python3")
 	os.OpenFile(pythonPath, os.O_CREATE, 0555)
@@ -177,7 +177,7 @@ func TestInstalledPython3WithEnsurepip(t *testing.T) {
 
 func TestInstalledPython3WithoutEnsurepip(t *testing.T) {
 	tempDir := t.TempDir()
-	defer testSetEnv("PATH", tempDir)()
+	t.Setenv("PATH", tempDir)
 
 	pythonPath := filepath.Join(tempDir, "python3")
 	os.OpenFile(pythonPath, os.O_CREATE, 0555)
@@ -208,7 +208,7 @@ func TestInstalledPython3WithoutEnsurepip(t *testing.T) {
 
 func TestInstalledVirtualenv(t *testing.T) {
 	tempDir := t.TempDir()
-	defer testSetEnv("PATH", tempDir)()
+	t.Setenv("PATH", tempDir)
 
 	venvPath := filepath.Join(tempDir, "virtualenv")
 	os.OpenFile(venvPath, os.O_CREATE, 0555)
@@ -371,12 +371,6 @@ func testCreateFile(t *testing.T, path string) func() {
 	}
 
 	return func() { file.Close() }
-}
-
-func testSetEnv(env string, value string) func() {
-	old := os.Getenv(env)
-	os.Setenv(env, value)
-	return func() { os.Setenv(env, old) }
 }
 
 func TestEnsurePipSuccessHelperProcess(t *testing.T) {


### PR DESCRIPTION
Inspired by https://github.com/roots/trellis-cli/pull/264

This automatically restores the value to its original value in Cleanup