### PR TITLE
Update Dockerfile: go 1.17, bullseye, python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # This docker image is for integration testing only.
 
-FROM golang:1.17-buster
+FROM golang:1.17-bullseye
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -9,24 +9,17 @@ ENV TEST_DUMMY=/test/dummy
 
 WORKDIR /app
 
-# CircleCI
-# https://circleci.com/docs/2.0/custom-images/
-RUN apt-get -q update && \
-    apt-get install -q -y --no-install-recommends git openssh-client openssh-server tar gzip && \
-    apt-get clean && apt-get -y autoremove && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# Trellis
+RUN git clone https://github.com/roots/trellis.git "${TEST_DUMMY}/trellis"
 
 # Ansible
-# https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#latest-releases-via-apt-debian
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367 && \
-    echo "deb http://ppa.launchpad.net/ansible/ansible/ubuntu trusty main" | tee -a /etc/apt/sources.list && \
-    apt-get -q update && \
-    apt-get install -q -y --no-install-recommends ansible && \
-    apt-get clean && apt-get -y autoremove && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get -q update && \
+    apt-get install -q -y --no-install-recommends python3-pip && \
+    apt-get clean && apt-get -y autoremove && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    cd "${TEST_DUMMY}/trellis" && pip install -r requirements.txt
 
-# Trellis
-RUN git clone https://github.com/roots/trellis.git "${TEST_DUMMY}/trellis" && \
-    cd "${TEST_DUMMY}/trellis" && \
-    ansible-galaxy install -r galaxy.yml
+# Ansible galaxy
+RUN cd "${TEST_DUMMY}/trellis" && ansible-galaxy install -r galaxy.yml
 
 # Bedrock
 RUN mkdir -p "${TEST_DUMMY}/site" && \


### PR DESCRIPTION
This also switches to pip for Trellis dependency management to ensure the proper versions of Ansible are installed.

Note: I already updated the docker images using this Dockerfile, just forgot to commit this.

cc @TangRufus 