### PR TITLE
Remove all ioutil usage

### DIFF
--- a/cmd/ad_hoc_playbook.go
+++ b/cmd/ad_hoc_playbook.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -16,7 +15,7 @@ func (p *AdHocPlaybook) DumpFiles() func() {
 		destination := filepath.Join(p.path, fileName)
 		contentByte := []byte(content)
 
-		if err := ioutil.WriteFile(destination, contentByte, 0644); err != nil {
+		if err := os.WriteFile(destination, contentByte, 0644); err != nil {
 			panic("Could not write temporary file. This is probably a bug in trellis-cli; please open an issue to let us know.")
 		}
 	}

--- a/cmd/alias.go
+++ b/cmd/alias.go
@@ -4,7 +4,6 @@ import (
 	_ "embed"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -100,7 +99,7 @@ func (c *AliasCommand) Run(args []string) int {
 		}
 	}
 
-	tempDir, tempDirErr := ioutil.TempDir("", "trellis-alias-")
+	tempDir, tempDirErr := os.MkdirTemp("", "trellis-alias-")
 	if tempDirErr != nil {
 		spinner.StopFail()
 		c.UI.Error(tempDirErr.Error())
@@ -129,7 +128,7 @@ func (c *AliasCommand) Run(args []string) int {
 
 	combined := ""
 	for _, environment := range remoteEnvironments {
-		part, err := ioutil.ReadFile(filepath.Join(tempDir, environment+".yml.part"))
+		part, err := os.ReadFile(filepath.Join(tempDir, environment+".yml.part"))
 		if err != nil {
 			spinner.StopFail()
 			c.UI.Error(err.Error())
@@ -139,7 +138,7 @@ func (c *AliasCommand) Run(args []string) int {
 	}
 
 	combinedYmlPath := filepath.Join(tempDir, "/combined.yml")
-	writeFileErr := ioutil.WriteFile(combinedYmlPath, []byte(combined), 0644)
+	writeFileErr := os.WriteFile(combinedYmlPath, []byte(combined), 0644)
 	if writeFileErr != nil {
 		spinner.StopFail()
 		c.UI.Error(writeFileErr.Error())

--- a/cmd/alias_test.go
+++ b/cmd/alias_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -91,10 +90,10 @@ func TestIntegrationAlias(t *testing.T) {
 		t.Error("wp-cli.trellis-alias.yml file not generated")
 	}
 
-	actualByte, _ := ioutil.ReadFile(actualPath)
+	actualByte, _ := os.ReadFile(actualPath)
 	actual := string(actualByte)
 
-	expectedByte, _ := ioutil.ReadFile("./testdata/expected/alias/wp-cli.trellis-alias.yml")
+	expectedByte, _ := os.ReadFile("./testdata/expected/alias/wp-cli.trellis-alias.yml")
 	expected := string(expectedByte)
 
 	if actual != expected {

--- a/cmd/db_open.go
+++ b/cmd/db_open.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -105,7 +104,7 @@ func (c *DBOpenCommand) Run(args []string) int {
 	}
 
 	// Prepare JSON file for db credentials
-	dbCredentialsJson, dbCredentialsErr := ioutil.TempFile("", "*.json")
+	dbCredentialsJson, dbCredentialsErr := os.CreateTemp("", "*.json")
 	if dbCredentialsErr != nil {
 		c.UI.Error(fmt.Sprintf("Error creating temporary db credentials JSON file: %s", dbCredentialsErr))
 	}
@@ -128,7 +127,7 @@ func (c *DBOpenCommand) Run(args []string) int {
 	}
 
 	// Read db credentials from JSON file.
-	dbCredentialsByte, readErr := ioutil.ReadFile(dbCredentialsJson.Name())
+	dbCredentialsByte, readErr := os.ReadFile(dbCredentialsJson.Name())
 	if readErr != nil {
 		c.UI.Error(fmt.Sprintf("Error reading db credentials JSON file: %s", readErr))
 		return 1

--- a/cmd/db_opener_sequel_ace.go
+++ b/cmd/db_opener_sequel_ace.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	_ "embed"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"text/template"
 	"time"
@@ -20,7 +19,7 @@ type DBOpenerSequelAce struct {
 var sequelAceSpfTemplate string
 
 func (o *DBOpenerSequelAce) Open(c DBCredentials) (err error) {
-	sequelAceSpf, sequelAceSpfErr := ioutil.TempFile("", "*.spf")
+	sequelAceSpf, sequelAceSpfErr := os.CreateTemp("", "*.spf")
 	if sequelAceSpfErr != nil {
 		return fmt.Errorf("Error creating temporary SequelAce SPF file: %s", sequelAceSpfErr)
 	}

--- a/cmd/dot_env_test.go
+++ b/cmd/dot_env_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -141,10 +140,10 @@ func TestIntegrationDotEnv(t *testing.T) {
 		t.Error(".env file not generated")
 	}
 
-	actualByte, _ := ioutil.ReadFile(actualPath)
+	actualByte, _ := os.ReadFile(actualPath)
 	actual := string(actualByte)
 
-	expectedByte, _ := ioutil.ReadFile("./testdata/expected/dot_env/.env")
+	expectedByte, _ := os.ReadFile("./testdata/expected/dot_env/.env")
 	expected := string(expectedByte)
 
 	if actual != expected {

--- a/cmd/droplet_create.go
+++ b/cmd/droplet_create.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -309,7 +308,7 @@ func checkSSHKey(ui cli.Ui, keyString string, publicKey ssh.PublicKey) error {
 
 func loadSSHKey(path string) (keyString string, publicKey ssh.PublicKey, err error) {
 	path, err = homedir.Expand(path)
-	key, err := ioutil.ReadFile(path)
+	key, err := os.ReadFile(path)
 	if err != nil {
 		return "", nil, err
 	}

--- a/cmd/key_generate_test.go
+++ b/cmd/key_generate_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -98,7 +97,7 @@ func TestKeyGenerateExistingPrivateKey(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	privateKeyPath := filepath.Join(tmpDir, "trellis_example_com_ed25519")
-	ioutil.WriteFile(privateKeyPath, []byte{}, 0666)
+	os.WriteFile(privateKeyPath, []byte{}, 0666)
 
 	ui := cli.NewMockUi()
 	keyGenerateCommand := NewKeyGenerateCommand(ui, trellis)
@@ -125,7 +124,7 @@ func TestKeyGenerateExistingPublicKey(t *testing.T) {
 
 	os.Mkdir(filepath.Join(trellis.Path, "public_keys"), os.ModePerm)
 	publicKeyPath := filepath.Join(trellis.Path, "public_keys", "trellis_example_com_ed25519.pub")
-	err := ioutil.WriteFile(publicKeyPath, []byte{}, 0666)
+	err := os.WriteFile(publicKeyPath, []byte{}, 0666)
 
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -248,7 +247,7 @@ func (c *NewCommand) YamlHeader(doc string) string {
 
 func addTrellisFile(path string) error {
 	path = filepath.Join(path, ".trellis.yml")
-	return ioutil.WriteFile(path, []byte{}, 0666)
+	return os.WriteFile(path, []byte{}, 0666)
 }
 
 func askDomain(ui cli.Ui, path string) (host string, err error) {

--- a/github/main.go
+++ b/github/main.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -87,7 +86,7 @@ func FetchLatestRelease(repo string, client *http.Client) (*Release, error) {
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 
 	if err != nil {
 		return nil, fmt.Errorf("Error reading API response: %v", err)

--- a/plugin/finder.go
+++ b/plugin/finder.go
@@ -14,7 +14,6 @@ limitations under the License.
 package plugin
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -35,7 +34,7 @@ func (o *finder) find() map[string]string {
 			continue
 		}
 
-		files, err := ioutil.ReadDir(dir)
+		files, err := os.ReadDir(dir)
 		if err != nil {
 			continue
 		}

--- a/plugin/finder_test.go
+++ b/plugin/finder_test.go
@@ -1,7 +1,6 @@
 package plugin
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -161,7 +160,7 @@ func TestIsExecutable(t *testing.T) {
 	tempDir := t.TempDir()
 
 	createTempFile := func(mode os.FileMode) (*os.File, error) {
-		file, err := ioutil.TempFile(tempDir, "trellis-")
+		file, err := os.CreateTemp(tempDir, "trellis-")
 		if err != nil {
 			return nil, err
 		}

--- a/trellis/config.go
+++ b/trellis/config.go
@@ -2,10 +2,11 @@ package trellis
 
 import (
 	"fmt"
-	"github.com/weppos/publicsuffix-go/publicsuffix"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
 	"log"
+	"os"
+
+	"github.com/weppos/publicsuffix-go/publicsuffix"
 )
 
 const DefaultSiteName = "example.com"
@@ -50,7 +51,7 @@ type Config struct {
 }
 
 func (t *Trellis) ParseConfig(path string) *Config {
-	configYaml, err := ioutil.ReadFile(path)
+	configYaml, err := os.ReadFile(path)
 
 	if err != nil {
 		log.Fatalln(err)

--- a/trellis/detector_test.go
+++ b/trellis/detector_test.go
@@ -1,7 +1,6 @@
 package trellis
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -20,7 +19,7 @@ func TestDetect(t *testing.T) {
 
 	devConfig := filepath.Join(devDir, "wordpress_sites.yml")
 
-	if err := ioutil.WriteFile(devConfig, []byte{}, 0666); err != nil {
+	if err := os.WriteFile(devConfig, []byte{}, 0666); err != nil {
 		t.Fatal(err)
 	}
 
@@ -80,7 +79,7 @@ func TestDetectTrellisProjectStructure(t *testing.T) {
 	os.MkdirAll(devDir, 0700)
 
 	devConfig := filepath.Join(devDir, "wordpress_sites.yml")
-	ioutil.WriteFile(devConfig, []byte{}, 0666)
+	os.WriteFile(devConfig, []byte{}, 0666)
 
 	project := &ProjectDetector{}
 

--- a/trellis/hosts_test.go
+++ b/trellis/hosts_test.go
@@ -1,7 +1,7 @@
 package trellis
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 )
 
@@ -20,7 +20,7 @@ func TestUpdateHosts(t *testing.T) {
 		t.Fatalf(err.Error())
 	}
 
-	content, err := ioutil.ReadFile(hostsFile)
+	content, err := os.ReadFile(hostsFile)
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/trellis/testing.go
+++ b/trellis/testing.go
@@ -1,7 +1,6 @@
 package trellis
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,7 +13,7 @@ func LoadFixtureProject(t *testing.T) func() {
 		t.Fatalf("err: %s", err)
 	}
 
-	tempDir, err := ioutil.TempDir("", "trellis")
+	tempDir, err := os.MkdirTemp("", "trellis")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -3,7 +3,6 @@ package trellis
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -259,7 +258,7 @@ func (t *Trellis) getDefaultSiteNameFromEnvironment(environment string) (siteNam
 
 func (t *Trellis) LoadCliConfig() *CliConfig {
 	config := &CliConfig{}
-	configYaml, err := ioutil.ReadFile(filepath.Join(t.ConfigPath(), ConfigFile))
+	configYaml, err := os.ReadFile(filepath.Join(t.ConfigPath(), ConfigFile))
 
 	if err != nil && !os.IsNotExist(err) {
 		log.Fatalln(err)
@@ -303,7 +302,7 @@ func (t *Trellis) WriteYamlFile(s interface{}, path string, header string) error
 	path = filepath.Join(t.Path, path)
 	data = append([]byte(header), data...)
 
-	if err := ioutil.WriteFile(path, data, 0666); err != nil {
+	if err := os.WriteFile(path, data, 0666); err != nil {
 		log.Fatal(err)
 	}
 

--- a/trellis/trellis_test.go
+++ b/trellis/trellis_test.go
@@ -2,7 +2,6 @@ package trellis
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -332,7 +331,7 @@ func TestLoadCliConfigWhenFileExists(t *testing.T) {
 	configFilePath := filepath.Join(tp.ConfigPath(), ConfigFile)
 	configContents := ``
 
-	if err := ioutil.WriteFile(configFilePath, []byte(configContents), 0666); err != nil {
+	if err := os.WriteFile(configFilePath, []byte(configContents), 0666); err != nil {
 		t.Fatal(err)
 	}
 

--- a/trellis/vault.go
+++ b/trellis/vault.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -122,7 +121,7 @@ func (t *Trellis) GenerateVaultPassFile(path string) error {
 	randomString := RandomStringGenerator{Length: 64}
 
 	vaultPass := randomString.Generate()
-	return ioutil.WriteFile(path, []byte(vaultPass), 0600)
+	return os.WriteFile(path, []byte(vaultPass), 0600)
 }
 
 func assertAvailablePRNG() {

--- a/trellis/virtualenv.go
+++ b/trellis/virtualenv.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -144,7 +143,7 @@ func (v *Virtualenv) UpdateBinShebangs(binGlob string) error {
 		permissions := fileInfo.Mode()
 		defer f.Close()
 
-		tmp, err := ioutil.TempFile("", "replace-"+filepath.Base(path))
+		tmp, err := os.CreateTemp("", "replace-"+filepath.Base(path))
 		if err != nil {
 			return err
 		}

--- a/update/main.go
+++ b/update/main.go
@@ -2,7 +2,6 @@ package update
 
 import (
 	"github.com/roots/trellis-cli/github"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -96,7 +95,7 @@ func (n *Notifier) getLatestReleaseInfo(stateFilePath string) (*github.Release, 
 }
 
 func getStateEntry(stateFilePath string) (*StateEntry, error) {
-	content, err := ioutil.ReadFile(stateFilePath)
+	content, err := os.ReadFile(stateFilePath)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +120,7 @@ func setStateEntry(stateFilePath string, t time.Time, r *github.Release) error {
 		return err
 	}
 
-	_ = ioutil.WriteFile(stateFilePath, content, 0600)
+	_ = os.WriteFile(stateFilePath, content, 0600)
 
 	return nil
 }

--- a/update/main_test.go
+++ b/update/main_test.go
@@ -2,7 +2,6 @@ package update
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -215,7 +214,7 @@ latest_release:
 		cacheDir := t.TempDir()
 
 		if tc.stateEntry != "" {
-			_ = ioutil.WriteFile(filepath.Join(cacheDir, "state.yml"), []byte(tc.stateEntry), 0600)
+			_ = os.WriteFile(filepath.Join(cacheDir, "state.yml"), []byte(tc.stateEntry), 0600)
 		}
 
 		if tc.githubResponse != "" {


### PR DESCRIPTION
All the `io/ioutil` functions used in trellis-cli are obsolete now since they either just call the replacement method in its implementation, or the replacement is a better choice (as of Go 1.16 and 1.17).