### PR TITLE
Fix cross-link bug for virtualenv

### DIFF
--- a/trellis/virtualenv.go
+++ b/trellis/virtualenv.go
@@ -148,25 +148,20 @@ func (v *Virtualenv) UpdateBinShebangs(binGlob string) error {
 			return err
 		}
 		defer tmp.Close()
+		defer os.Remove(tmp.Name())
 
 		if err = v.replaceShebang(f, tmp); err != nil {
 			return err
 		}
 
-		if err := tmp.Close(); err != nil {
-			return err
-		}
-
-		if err := f.Close(); err != nil {
-			return err
-		}
-
 		// overwrite the original bin file with the fixed version
-		if err := os.Rename(tmp.Name(), path); err != nil {
+		if _, err = io.Copy(tmp, f); err != nil {
 			return err
 		}
 
-		os.Chmod(path, permissions)
+		if err = os.Chmod(path, permissions); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #281

It's not possible to rename/move a file across filesystems. Instead of renaming, this copies the file contents over instead.