### PR TITLE
Update python check command to python3

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -16,7 +16,7 @@ type CheckCommand struct {
 var Requirements = []trellis.Requirement{
 	{
 		Name:              "Python",
-		Command:           "python",
+		Command:           "python3",
 		Optional:          false,
 		Url:               "https://www.python.org/",
 		VersionConstraint: ">= 3.8.0",


### PR DESCRIPTION
Since Python 3 is required now, this should run the `python3` command instead of `python`.