### PR TITLE
Fix venv hook shell escaping

### DIFF
--- a/cmd/venv_hook.go
+++ b/cmd/venv_hook.go
@@ -22,17 +22,17 @@ func (c *VenvHookCommand) Run(args []string) int {
 	if c.Trellis.ActivateProject() {
 		if !ok {
 			fmt.Fprintf(color.Error, "[trellis] \x1b[1;32mactivated env\x1b[0m\n")
-			c.UI.Output(fmt.Sprintf("export %s=\"%s\"", trellis.VenvEnvName, shellescape.Quote(c.Trellis.Virtualenv.Path)))
-			c.UI.Output(fmt.Sprintf("export %s=\"%s\"", trellis.OldPathEnvName, shellescape.Quote(c.Trellis.Virtualenv.OldPath)))
-			c.UI.Output(fmt.Sprintf("export %s=\"%s\":\"%s\"", trellis.PathEnvName, shellescape.Quote(c.Trellis.Virtualenv.BinPath), shellescape.Quote(c.Trellis.Virtualenv.OldPath)))
+			c.exportEnv(trellis.VenvEnvName, c.Trellis.Virtualenv.Path)
+			c.exportEnv(trellis.OldPathEnvName, c.Trellis.Virtualenv.OldPath)
+			newPath := fmt.Sprintf("%s:%s", c.Trellis.Virtualenv.BinPath, c.Trellis.Virtualenv.OldPath)
+			c.exportEnv(trellis.PathEnvName, newPath)
 		}
 	} else {
 		if ok {
 			fmt.Fprintf(color.Error, "[trellis] \x1b[1;31mdeactivated env\x1b[0m\n")
-			path := os.Getenv(trellis.OldPathEnvName)
 			c.UI.Output(fmt.Sprintf("unset %s", trellis.VenvEnvName))
 			c.UI.Output(fmt.Sprintf("unset %s", trellis.OldPathEnvName))
-			c.UI.Output(fmt.Sprintf("export %s=%s", trellis.PathEnvName, shellescape.Quote(path)))
+			c.exportEnv(trellis.PathEnvName, os.Getenv(trellis.OldPathEnvName))
 		}
 	}
 
@@ -56,4 +56,8 @@ Options:
 `
 
 	return strings.TrimSpace(helpText)
+}
+
+func (c *VenvHookCommand) exportEnv(key string, value string) {
+	c.UI.Output(fmt.Sprintf("export %s=%s", key, shellescape.Quote(value)))
 }

--- a/cmd/venv_hook_test.go
+++ b/cmd/venv_hook_test.go
@@ -12,6 +12,7 @@ import (
 func TestVenvHookRunActivatesEnv(t *testing.T) {
 	os.Unsetenv(trellis.OldPathEnvName)
 	defer trellis.LoadFixtureProject(t)()
+	t.Setenv(trellis.PathEnvName, "/path/to folder")
 
 	ui := cli.NewMockUi()
 	tp := trellis.NewTrellis()
@@ -25,9 +26,9 @@ func TestVenvHookRunActivatesEnv(t *testing.T) {
 
 	combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
 
-	venv := fmt.Sprintf("export %s=\"%s\"", trellis.VenvEnvName, tp.Virtualenv.Path)
-	oldPath := fmt.Sprintf("export %s=\"%s\"", trellis.OldPathEnvName, tp.Virtualenv.OldPath)
-	path := fmt.Sprintf("export %s=\"%s\":\"%s\"", trellis.PathEnvName, tp.Virtualenv.BinPath, tp.Virtualenv.OldPath)
+	venv := fmt.Sprintf("export %s=%s", trellis.VenvEnvName, tp.Virtualenv.Path)
+	oldPath := fmt.Sprintf("export %s='%s'", trellis.OldPathEnvName, tp.Virtualenv.OldPath)
+	path := fmt.Sprintf("export %s='%s:%s'", trellis.PathEnvName, tp.Virtualenv.BinPath, tp.Virtualenv.OldPath)
 
 	expected := fmt.Sprintf("%s\n%s\n%s\n", venv, oldPath, path)
 
@@ -37,7 +38,7 @@ func TestVenvHookRunActivatesEnv(t *testing.T) {
 }
 
 func TestVenvHookRunDeactivatesEnv(t *testing.T) {
-	t.Setenv(trellis.OldPathEnvName, "foo")
+	t.Setenv(trellis.OldPathEnvName, "foo bar")
 
 	ui := cli.NewMockUi()
 	trellis := trellis.NewMockTrellis(false)
@@ -53,7 +54,7 @@ func TestVenvHookRunDeactivatesEnv(t *testing.T) {
 
 	expected := `unset VIRTUAL_ENV
 unset PRE_TRELLIS_PATH
-export PATH=foo
+export PATH='foo bar'
 `
 
 	if combined != expected {


### PR DESCRIPTION
Fixes #295 

This removes the explicit wrapping of env values in double quotes and just relies on the `shellescape` library. Before it could result in double quoting (eg: export PATH="'/path/to folder/bin'").