### PR TITLE
Fix virtualenv shebangs updating

### DIFF
--- a/trellis/virtualenv_test.go
+++ b/trellis/virtualenv_test.go
@@ -270,9 +270,7 @@ next line
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			r := strings.NewReader(tc.input)
-			var b bytes.Buffer
-
-			venv.replaceShebang(r, &b)
+			b, _ := venv.replaceShebang(r)
 
 			if b.String() != tc.output {
 				t.Errorf("%s\n expected output: %s\ngot: %s", tc.name, tc.output, b.String())


### PR DESCRIPTION
https://github.com/roots/trellis-cli/pull/282 migrated from moving files to copying the contents, but it was broken (the order of arguments in `io.Copy` was wrong).

This fixes the file updating and simplifies the code by just using a buffer instead of temp files since we're not actually moving files.