### PR TITLE
Add local env support to alias cmd

### DIFF
--- a/cmd/files/playbooks/alias_template.yml.j2
+++ b/cmd/files/playbooks/alias_template.yml.j2
@@ -1,0 +1,9 @@
+{% if include_local_env | default(false) %}
+@{{ env }}:
+  ssh: "{{ local_hostname_alias }}"
+  path: "{{ project_root | default(www_root + '/' + item.key) | regex_replace('^~\/','') }}/{{ item.current_path | default('current') }}/web/wp"
+{% else %}
+@{{ env }}:
+  ssh: "{{ web_user }}@{{ ansible_host }}:{{ ansible_port | default('22') }}"
+  path: "{{ project_root | default(www_root + '/' + item.key) | regex_replace('^~\/','') }}/{{ item.current_path | default('current') }}/web/wp"
+{% endif %}

--- a/cmd/testdata/expected/alias/wp-cli.trellis-alias.yml
+++ b/cmd/testdata/expected/alias/wp-cli.trellis-alias.yml
@@ -1,3 +1,6 @@
+@development:
+  ssh: "example.test"
+  path: "/srv/www/example.com/current/web/wp"
 @production:
   ssh: "web@your_server_hostname:22"
   path: "/srv/www/example.com/current/web/wp"


### PR DESCRIPTION
Defaults to including the local env in `trellis alias` to include the Vagrant development environment.

For proper SSH support, this defaults to using the _main host_ which is what Trellis configures Vagrant to use as an SSH alias name (in your SSH config).

For non-Vagrant users, or any other non-default setup, `--skip-local` can be used to maintain the old behaviour.