### PR TITLE
Improve failure output for commands

### DIFF
--- a/cmd/db_open.go
+++ b/cmd/db_open.go
@@ -119,10 +119,15 @@ func (c *DBOpenCommand) Run(args []string) int {
 		"-e", "site=" + siteName,
 		"-e", "dest=" + dbCredentialsJson.Name(),
 	}
-	dumpDbCredentials := command.Cmd("ansible-playbook", playbookArgs)
+
+	mockUi := cli.NewMockUi()
+	dumpDbCredentials := command.WithOptions(
+		command.WithUiOutput(mockUi),
+	).Cmd("ansible-playbook", playbookArgs)
 
 	if err := dumpDbCredentials.Run(); err != nil {
-		c.UI.Error(fmt.Sprintf("Error running ansible-playbook dump_db_credentials.yml: %s", err))
+		c.UI.Error("Error opening database. Temporary playbook failed to execute:")
+		c.UI.Error(mockUi.ErrorWriter.String())
 		return 1
 	}
 

--- a/cmd/dot_env.go
+++ b/cmd/dot_env.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	_ "embed"
 	"flag"
-	"fmt"
 	"strings"
 
 	"github.com/mitchellh/cli"
@@ -70,11 +69,14 @@ func (c *DotEnvCommand) Run(args []string) int {
 
 	defer c.playbook.DumpFiles()()
 
-	dotenv := command.Cmd("ansible-playbook", []string{"dotenv.yml", "-e", "env=" + environment})
+	mockUi := cli.NewMockUi()
+	dotenv := command.WithOptions(
+		command.WithUiOutput(mockUi),
+	).Cmd("ansible-playbook", []string{"dotenv.yml", "-e", "env=" + environment})
 
 	if err := dotenv.Run(); err != nil {
 		spinner.StopFail()
-		c.UI.Error(fmt.Sprintf("Error running ansible-playbook: %s", err))
+		c.UI.Error(mockUi.ErrorWriter.String())
 		return 1
 	}
 

--- a/cmd/vault_decrypt.go
+++ b/cmd/vault_decrypt.go
@@ -87,11 +87,18 @@ func (c *VaultDecryptCommand) Run(args []string) int {
 
 	vaultArgs = append(vaultArgs, filesToDecrypt...)
 
-	vaultDecrypt := command.WithOptions(command.WithTermOutput(), command.WithLogging(c.UI)).Cmd("ansible-vault", vaultArgs)
+	mockUi := cli.NewMockUi()
+	vaultDecrypt := command.WithOptions(
+		command.WithUiOutput(mockUi),
+		command.WithLogging(c.UI),
+	).Cmd("ansible-vault", vaultArgs)
 
-	if err := vaultDecrypt.Run(); err == nil {
-		c.UI.Info(color.GreenString("Decryption successful"))
+	if err := vaultDecrypt.Run(); err != nil {
+		c.UI.Error(mockUi.ErrorWriter.String())
+		return 1
 	}
+
+	c.UI.Info(color.GreenString("Decryption successful"))
 
 	return 0
 }

--- a/cmd/vault_encrypt.go
+++ b/cmd/vault_encrypt.go
@@ -113,11 +113,18 @@ func (c *VaultEncryptCommand) Run(args []string) int {
 	vaultArgs := []string{"encrypt"}
 	vaultArgs = append(vaultArgs, filesToEncrypt...)
 
-	vaultEncrypt := command.WithOptions(command.WithTermOutput(), command.WithLogging(c.UI)).Cmd("ansible-vault", vaultArgs)
+	mockUi := cli.NewMockUi()
+	vaultEncrypt := command.WithOptions(
+		command.WithUiOutput(mockUi),
+		command.WithLogging(c.UI),
+	).Cmd("ansible-vault", vaultArgs)
 
-	if err := vaultEncrypt.Run(); err == nil {
-		c.UI.Info(color.GreenString("Encryption successful"))
+	if err := vaultEncrypt.Run(); err != nil {
+		c.UI.Error(mockUi.ErrorWriter.String())
+		return 1
 	}
+
+	c.UI.Info(color.GreenString("Encryption successful"))
 
 	return 0
 }


### PR DESCRIPTION
Fixes #300 

This improves failure handling and output for two types of commands:
1. ones that use ad hoc playbooks
2. vault related

In both cases trellis-cli wasn't outputting useful error output from the underlying Ansible commands making it harder to troubleshoot.

The solution is to capture the output and conditionally display the error output when the underlying command fails.