### PR TITLE
Fixes #309 - Better GitHub API error messages

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -113,7 +113,7 @@ func (c *NewCommand) Run(args []string) int {
 	if err != nil {
 		c.UI.Error("Aborting: error while downloading Trellis")
 		c.UI.Error(err.Error())
-		c.UI.Error("This might just be a network error. Please delete this project folder and try again.")
+		c.UI.Error("\nThis could be a temporary network error. Please delete this project folder and try again.")
 		return 1
 	}
 
@@ -121,7 +121,7 @@ func (c *NewCommand) Run(args []string) int {
 	if err != nil {
 		c.UI.Error("Aborting: error while downloading Bedrock")
 		c.UI.Error(err.Error())
-		c.UI.Error("This might just be a network error. Please delete this project folder and try again.")
+		c.UI.Error("\nThis could be a temporary network error. Please delete this project folder and try again.")
 		return 1
 	}
 


### PR DESCRIPTION
Improve error handling and error messages when using the GitHub API to download Trellis and Bedrock.

This will pass through actual GitHub HTTP error responses for non-200 status codes. This is helpful to debug rate limit or authentication issues.

Note: trellis-cli should probably support a GitHub API auth token eventually, but this helps for now.