### PR TITLE
Fix #271 - Add ask_vault_pass config setting

### DIFF
--- a/trellis/cli_config.go
+++ b/trellis/cli_config.go
@@ -1,5 +1,19 @@
 package trellis
 
+import (
+	"os"
+)
+
 type CliConfig struct {
-	Open map[string]string `yaml:"open"`
+	AskVaultPass bool              `yaml:"ask_vault_pass"`
+	Open         map[string]string `yaml:"open"`
+}
+
+func (c *CliConfig) Init() error {
+	if c.AskVaultPass {
+		// https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-ask-vault-pass
+		os.Setenv("ANSIBLE_ASK_VAULT_PASS", "true")
+	}
+
+	return nil
 }

--- a/trellis/cli_config_test.go
+++ b/trellis/cli_config_test.go
@@ -1,0 +1,30 @@
+package trellis
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCliConfigInit(t *testing.T) {
+	config := CliConfig{}
+	config.Init()
+
+	_, ok := os.LookupEnv("ANSIBLE_ASK_VAULT_PASS")
+
+	if ok {
+		t.Error("expected ANSIBLE_ASK_VAULT_PASS to not be set")
+	}
+}
+
+func TestCliConfigInitEnablesAskVaultPass(t *testing.T) {
+	config := CliConfig{AskVaultPass: true}
+	config.Init()
+
+	env := os.Getenv("ANSIBLE_ASK_VAULT_PASS")
+
+	os.Setenv("ANSIBLE_ASK_VAULT_PASS", "")
+
+	if env != "true" {
+		t.Error("expected ANSIBLE_ASK_VAULT_PASS to be true")
+	}
+}

--- a/trellis/trellis_test.go
+++ b/trellis/trellis_test.go
@@ -316,7 +316,7 @@ func TestLoadProjectForProjects(t *testing.T) {
 func TestLoadCliConfigWhenFileDoesNotExist(t *testing.T) {
 	tp := NewTrellis()
 
-	config := tp.LoadCliConfig()
+	config, _ := tp.LoadCliConfig()
 
 	if config == nil {
 		t.Error("expected config object")
@@ -335,7 +335,7 @@ func TestLoadCliConfigWhenFileExists(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	config := tp.LoadCliConfig()
+	config, _ := tp.LoadCliConfig()
 
 	if !reflect.DeepEqual(config, &CliConfig{}) {
 		t.Error("expected open object")


### PR DESCRIPTION
Setting `ask_vault_pass` to true will make Ansible always prompt for the Vault password _instead_ of reading it from the `vault_pass_file` (specific in `ansible.cfg`).

This is done by setting the `ANSIBLE_ASK_VAULT_PASS` environment variable to `true`.