### PR TITLE
Project detection: drop site folder requirement

### DIFF
--- a/trellis/detector_test.go
+++ b/trellis/detector_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 )
 
-const testDir = "tmp"
-
 func TestDetect(t *testing.T) {
 	testDir := t.TempDir()
 
@@ -69,10 +67,8 @@ func TestDetectTrellisProjectStructure(t *testing.T) {
 
 	trellisDir := filepath.Join(testDir, "trellis")
 	siteDir := filepath.Join(testDir, "site")
-
 	os.Mkdir(trellisDir, 0700)
 	os.Mkdir(siteDir, 0700)
-
 	os.Mkdir(filepath.Join(trellisDir, ConfigDir), 0700)
 
 	devDir := filepath.Join(trellisDir, "group_vars", "development")


### PR DESCRIPTION
This makes the project detector more flexible and less strict by dropping the `site` folder requirement. Previously the detector would only recognize the recommended folder structure when not directly inside a `trellis` folder. Your project would have to be structured like this:

```plain
example.com/       # → Root folder for the project
├── trellis/       # → Your server configuration (a customized install of Trellis)
    └── .trellis/  # → trellis-cli config directory
└── site/          # → A Bedrock-based WordPress site
    └── web/
```

`site` was required to limit false positives but isn't necessary due to the other requirement for the `.trellis` config directory.

By dropping the `site requirement`, this means trellis-cli will work better in two other known folder structures:

* where the "site" folder exists but it named differently some_project_name/ # → Root folder for the project
```plain
├── trellis/       # → Your server configuration (a customized install of Trellis)
    └── .trellis/  # → trellis-cli config directory
└── example.com/   # → A Bedrock-based WordPress site
    └── web/
```

* where the root _is_ the site contents, and trellis is a subdirectory
```plain
example.com/       # → A Bedrock-based WordPress site
└── web/
├── trellis/       # → Your server configuration (a customized install of Trellis)
    └── .trellis/  # → trellis-cli config directory
```