### PR TITLE
droplet create command: Support ed25519 SSH keys

### DIFF
--- a/digitalocean/main.go
+++ b/digitalocean/main.go
@@ -2,6 +2,7 @@ package digitalocean
 
 import (
 	"context"
+	"fmt"
 	"os/user"
 	"sort"
 	"strings"
@@ -70,7 +71,7 @@ func (do *Client) CreateSSHKey(key string) error {
 	_, _, err = do.Client.Keys.Create(ctx, createRequest)
 
 	if err != nil {
-		return err
+		return fmt.Errorf("Could not create SSH key on DigitalOcean: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
Adds support for both ed25519 and rsa SSH keys. Previously this used `~/.ssh/id_rsa.pub` as the default `ssh-key` option value which forced users with ed25519 keys to manually specify the key path.

Now trellis-cli will check both `~/.sss/id_ed25519.pub` and `~/.sss/id_rsa.pub` keys by default.

This also improves failure handling and output of SSH key related functionality including outputting the path of the key being used to make it more obvious.