### PR TITLE
Prevent deploys to development by default

### DIFF
--- a/cli_config/cli_config.go
+++ b/cli_config/cli_config.go
@@ -12,11 +12,12 @@ import (
 )
 
 type Config struct {
-	AskVaultPass          bool              `yaml:"ask_vault_pass"`
-	CheckForUpdates       bool              `yaml:"check_for_updates"`
-	LoadPlugins           bool              `yaml:"load_plugins"`
-	Open                  map[string]string `yaml:"open"`
-	VirtualenvIntegration bool              `yaml:"virtualenv_integration"`
+	AllowDevelopmentDeploys bool              `yaml:"allow_development_deploys"`
+	AskVaultPass            bool              `yaml:"ask_vault_pass"`
+	CheckForUpdates         bool              `yaml:"check_for_updates"`
+	LoadPlugins             bool              `yaml:"load_plugins"`
+	Open                    map[string]string `yaml:"open"`
+	VirtualenvIntegration   bool              `yaml:"virtualenv_integration"`
 }
 
 var (

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -63,6 +63,24 @@ func (c *DeployCommand) Run(args []string) int {
 		return 1
 	}
 
+	if environment == "development" && !c.Trellis.CliConfig.AllowDevelopmentDeploys {
+		c.UI.Error(`
+Error: deploying to the development environment is not supported by default.
+
+Most local development environments (like Vagrant) handle file sharing automatically.
+Local site files are automatically synced/shared to the VM so there's no need to manually deploy a site.
+
+See https://docs.roots.io/trellis/master/local-development/#vagrant for more details on Vagrant with Trellis.
+
+If you're using a non-standard development setup (such as a remote cloud environment) and want to deploy,
+you can disable this check by setting the following config value in your CLI config:
+
+  allow_development_deploys: true
+    `)
+
+		return 1
+	}
+
 	siteNameArg := c.flags.Arg(1)
 	siteName, siteNameErr := c.Trellis.FindSiteNameFromEnvironment(environment, siteNameArg)
 	if siteNameErr != nil {

--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -31,11 +31,12 @@ type Options struct {
 type TrellisOption func(*Trellis)
 
 var DefaultCliConfig = cli_config.Config{
-	AskVaultPass:          false,
-	CheckForUpdates:       true,
-	LoadPlugins:           true,
-	Open:                  make(map[string]string),
-	VirtualenvIntegration: true,
+	AllowDevelopmentDeploys: false,
+	AskVaultPass:            false,
+	CheckForUpdates:         true,
+	LoadPlugins:             true,
+	Open:                    make(map[string]string),
+	VirtualenvIntegration:   true,
 }
 
 type Trellis struct {


### PR DESCRIPTION
Closes #335

Deploying to the development environment isn't needed by default since most local development environments sync/share site files automatically (like Vagrant does).

Running `trellis deploy development` can actually break a WordPress so this prevents it by default.

If someone is using a non-standard dev setup and does need to deploy (maybe to a remote cloud dev server?), a CLI config setting can be enabled to allow it.