### PR TITLE
Add logs command to view/tail Nginx log files

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,13 +141,17 @@ Supported commands so far:
 | `galaxy` | Commands for Ansible Galaxy |
 | `info` | Displays information about this Trellis project |
 | `init` | Initializes an existing Trellis project |
+| `key` | Commands for managing SSH keys |
+| `logs` | Tails the Nginx log files |
 | `new` | Creates a new Trellis project |
+| `open` | Opens user-defined URLs (and more) which can act as shortcuts/bookmarks specific to your Trellis projects |
 | `provision` | Provisions the specified environment |
 | `rollback` | Rollsback the last deploy of the site on the specified environment |
 | `ssh` | Connects to host via SSH |
 | `up` | Starts and provisions the Vagrant environment by running `vagrant up` |
 | `valet` | Commands for Laravel Valet |
 | `vault` | Commands for Ansible Vault |
+| `xdebug-tunnel` | Commands for managing Xdebug tunnels |
 
 ## Configuration
 There are three ways to set configuration settings for trellis-cli and they are

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,0 +1,231 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/roots/trellis-cli/command"
+	"github.com/roots/trellis-cli/trellis"
+)
+
+func NewLogsCommand(ui cli.Ui, trellis *trellis.Trellis) *LogsCommand {
+	c := &LogsCommand{UI: ui, Trellis: trellis}
+	c.init()
+	return c
+}
+
+type LogsCommand struct {
+	UI            cli.Ui
+	flags         *flag.FlagSet
+	access        bool
+	error         bool
+	goaccess      bool
+	goaccessFlags string
+	number        string
+	Trellis       *trellis.Trellis
+}
+
+func (c *LogsCommand) init() {
+	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+	c.flags.Usage = func() { c.UI.Info(c.Help()) }
+	c.flags.BoolVar(&c.access, "access", false, "Show access logs only")
+	c.flags.BoolVar(&c.error, "error", false, "Show error logs only")
+	c.flags.StringVar(&c.goaccessFlags, "goaccess-flags", "", "Flags to pass to the goaccess command (in quotes)")
+	c.flags.BoolVar(&c.goaccess, "g", false, "Uses goaccess as the log viewer instead of tail")
+	c.flags.BoolVar(&c.goaccess, "goaccess", false, "Uses goaccess as the log viewer instead of tail")
+	c.flags.StringVar(&c.number, "n", "", "Location (number lines) corresponding to tail's '-n' option")
+	c.flags.StringVar(&c.number, "number", "", "Location (number lines) corresponding to tail's '-n' option")
+}
+
+func (c *LogsCommand) Run(args []string) int {
+	if err := c.Trellis.LoadProject(); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	c.Trellis.CheckVirtualenv(c.UI)
+
+	if err := c.flags.Parse(args); err != nil {
+		return 1
+	}
+
+	args = c.flags.Args()
+
+	commandArgumentValidator := &CommandArgumentValidator{required: 1, optional: 1}
+	commandArgumentErr := commandArgumentValidator.validate(args)
+	if commandArgumentErr != nil {
+		c.UI.Error(commandArgumentErr.Error())
+		c.UI.Output(c.Help())
+		return 1
+	}
+
+	environment := args[0]
+	environmentErr := c.Trellis.ValidateEnvironment(environment)
+	if environmentErr != nil {
+		c.UI.Error(environmentErr.Error())
+		return 1
+	}
+
+	siteNameArg := ""
+	if len(args) == 2 {
+		siteNameArg = args[1]
+	}
+	siteName, siteNameErr := c.Trellis.FindSiteNameFromEnvironment(environment, siteNameArg)
+	if siteNameErr != nil {
+		c.UI.Error(siteNameErr.Error())
+		return 1
+	}
+
+	sshHost := c.Trellis.SshHost(environment, siteName, "web")
+
+	_, err := exec.LookPath("goaccess")
+
+	if (c.goaccess || c.goaccessFlags != "") && err == nil {
+		tailCmd := c.tailCmd(siteName, "goaccess")
+		logArgs := []string{sshHost, tailCmd}
+
+		ssh := command.Cmd("ssh", logArgs)
+		goaccessArgs := []string{"--log-format=COMBINED"}
+
+		if c.goaccessFlags != "" {
+			goaccessArgs = append(goaccessArgs, strings.Split(c.goaccessFlags, " ")...)
+		}
+
+		goaccess := command.WithOptions(
+			command.WithTermOutput(),
+		).Cmd("goaccess", goaccessArgs)
+
+		goaccess.Stdin, _ = ssh.StdoutPipe()
+
+		if err := ssh.Start(); err != nil {
+			c.UI.Error(fmt.Sprintf("Error starting SSH command: %s", err))
+			return 1
+		}
+
+		if err := goaccess.Start(); err != nil {
+			c.UI.Error(fmt.Sprintf("Error starting goaccess command: %s", err))
+			return 1
+		}
+
+		if err := goaccess.Wait(); err != nil {
+			c.UI.Error(fmt.Sprintf("Error running goaccess command: %s", err))
+			return 1
+		}
+		if err := ssh.Wait(); err != nil {
+			c.UI.Error(fmt.Sprintf("Error running SSH command: %s", err))
+			return 1
+		}
+	} else {
+		logArgs := []string{sshHost, c.tailCmd(siteName, "tail")}
+
+		ssh := command.WithOptions(
+			command.WithTermOutput(),
+			command.WithLogging(c.UI),
+		).Cmd("ssh", logArgs)
+
+		if err := ssh.Run(); err != nil {
+			c.UI.Error(fmt.Sprintf("Error running ssh: %s", err))
+			return 1
+		}
+	}
+
+	return 0
+}
+
+func (c *LogsCommand) Synopsis() string {
+	return "Tails the Nginx log files for an environment"
+}
+
+func (c *LogsCommand) Help() string {
+	helpText := `
+Usage: trellis logs [options] ENVIRONMENT [SITE]
+
+Tails the Nginx log files (access and error) for an environment.
+
+Automatically integrates with https://goaccess.io/ when the --goaccess option is used.
+
+Note: this command relies on an SSH connection to the environment's hostname to remotely
+tail the log files. It depends on SSH keys being setup properly for a passwordless SSH connection.
+If the 'trellis ssh' command does not work, this logs command won't work either.
+
+View production logs:
+
+  $ trellis logs production
+
+View access logs only:
+
+  $ trellis logs --access production
+
+View error logs only:
+
+  $ trellis logs --error production
+
+View logs in goaccess:
+
+  $ trellis logs --goaccess production
+
+Pass flags to goaccess:
+
+  $ trellis logs --goaccess-flags="-a -m" production
+
+View the last 50 log lines (-n corresponds to tail's -n option):
+
+  $ trellis logs -n 50 production
+
+Arguments:
+  ENVIRONMENT Name of environment (ie: production)
+  SITE        Name of site (ie: example.com)
+  
+Options:
+      --access          Show access logs only
+      --error           Show error logs only
+  -g, --goaccess        Uses goaccess as the log viewer instead of tail
+      --goaccess-flags  Flags to pass to the goaccess command (in quotes)
+  -n, --number          Location (number lines) corresponding to tail's '-n' argument
+  -h, --help            Show this help
+`
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *LogsCommand) AutocompleteArgs() complete.Predictor {
+	return c.Trellis.AutocompleteSite(flag.NewFlagSet("", flag.ContinueOnError))
+}
+
+func (c *LogsCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"--access":         complete.PredictNothing,
+		"--error":          complete.PredictNothing,
+		"--goaccess":       complete.PredictNothing,
+		"--goaccess-flags": complete.PredictNothing,
+		"--number":         complete.PredictNothing,
+	}
+}
+
+func (c *LogsCommand) tailCmd(siteName string, mode string) string {
+	file := "*[^gz]?" // exclude gzipped log files by default
+
+	if c.access {
+		file = "access.log"
+	} else if c.error {
+		file = "error.log"
+	} else if mode == "goaccess" {
+		// goaccess supports gzipped log files so we can include them
+		file = "*"
+	}
+
+	n := ""
+	if c.number == "" && mode == "goaccess" {
+		// default to load entire file in Goaccess
+		// this makes more sense in this context than for viewing in terminal
+		n = "-n +0 "
+	} else if c.number != "" {
+		n = fmt.Sprintf("-n %s ", c.number)
+	}
+
+	return fmt.Sprintf("tail %s-f /srv/www/%s/logs/%s", n, siteName, file)
+}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -144,7 +144,7 @@ func (c *LogsCommand) Help() string {
 	helpText := `
 Usage: trellis logs [options] ENVIRONMENT [SITE]
 
-Tails the Nginx log files (access and error) for an environment.
+Tails the Nginx log files for an environment.
 
 Automatically integrates with https://goaccess.io/ when the --goaccess option is used.
 

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -1,0 +1,225 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/cli"
+	"github.com/roots/trellis-cli/trellis"
+)
+
+func TestLogsRunValidations(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
+
+	cases := []struct {
+		name            string
+		projectDetected bool
+		args            []string
+		out             string
+		code            int
+	}{
+		{
+			"no_project",
+			false,
+			nil,
+			"No Trellis project detected",
+			1,
+		},
+		{
+			"too_many_args",
+			true,
+			[]string{"development", "example.com", "bar"},
+			"Error: too many arguments",
+			1,
+		},
+		{
+			"invalid_env",
+			true,
+			[]string{"foo"},
+			"Error: foo is not a valid environment",
+			1,
+		},
+		{
+			"invalid_site",
+			true,
+			[]string{"development", "foo"},
+			"Error: foo is not a valid site",
+			1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ui := cli.NewMockUi()
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
+			logsCommand := NewLogsCommand(ui, trellis)
+
+			code := logsCommand.Run(tc.args)
+
+			if code != tc.code {
+				t.Errorf("expected code %d to be %d", code, tc.code)
+			}
+
+			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+
+			if !strings.Contains(combined, tc.out) {
+				t.Errorf("expected output %q to contain %q", combined, tc.out)
+			}
+		})
+	}
+}
+
+func TestLogsRun(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
+	trellis := trellis.NewTrellis()
+
+	cases := []struct {
+		name string
+		args []string
+		out  string
+		code int
+	}{
+		{
+			"default",
+			[]string{"development"},
+			"ssh vagrant@example.test tail -f /srv/www/example.com/logs/*[^gz]?",
+			0,
+		},
+		{
+			"access option",
+			[]string{"--access", "development"},
+			"ssh vagrant@example.test tail -f /srv/www/example.com/logs/access.log",
+			0,
+		},
+		{
+			"error option",
+			[]string{"--error", "development"},
+			"ssh vagrant@example.test tail -f /srv/www/example.com/logs/error.log",
+			0,
+		},
+		{
+			"number option",
+			[]string{"--number=10", "development"},
+			"ssh vagrant@example.test tail -n 10 -f /srv/www/example.com/logs/*[^gz]?",
+			0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ui := cli.NewMockUi()
+			defer MockUiExec(t, ui)()
+
+			logsCommand := NewLogsCommand(ui, trellis)
+			code := logsCommand.Run(tc.args)
+
+			if code != tc.code {
+				t.Errorf("expected code %d to be %d", code, tc.code)
+			}
+
+			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+
+			if !strings.Contains(combined, tc.out) {
+				t.Errorf("expected output %q to contain %q", combined, tc.out)
+			}
+		})
+	}
+}
+
+func TestLogsRunGoAccess(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
+	trellis := trellis.NewTrellis()
+
+	tmpDir := t.TempDir()
+
+	// fake goaccess binary to satisfy ok.LookPath
+	goAccessPath := filepath.Join(tmpDir, "goaccess")
+	os.OpenFile(goAccessPath, os.O_CREATE, 0555)
+	path := os.Getenv("PATH")
+	t.Setenv("PATH", fmt.Sprintf("PATH=%s:%s", path, tmpDir))
+
+	cases := []struct {
+		name string
+		args []string
+		out  []string
+		code int
+	}{
+		{
+			"goaccess",
+			[]string{"--goaccess", "development"},
+			[]string{
+				"ssh vagrant@example.test tail -n +0 -f /srv/www/example.com/logs/*",
+				"goaccess --log-format=COMBINED",
+			},
+			0,
+		},
+		{
+			"goaccess flags",
+			[]string{"--goaccess", "--goaccess-flags=-a -m", "development"},
+			[]string{
+				"ssh vagrant@example.test tail -n +0 -f /srv/www/example.com/logs/*",
+				"goaccess --log-format=COMBINED -a -m",
+			},
+			0,
+		},
+		{
+			"goaccess with access only",
+			[]string{"--goaccess", "--access", "development"},
+			[]string{
+				"ssh vagrant@example.test tail -n +0 -f /srv/www/example.com/logs/access.log",
+				"goaccess --log-format=COMBINED",
+			},
+			0,
+		},
+		{
+			"goaccess with error only",
+			[]string{"--goaccess", "--error", "development"},
+			[]string{
+				"ssh vagrant@example.test tail -n +0 -f /srv/www/example.com/logs/error.log",
+				"goaccess --log-format=COMBINED",
+			},
+			0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ui := cli.NewMockUi()
+			defer MockUiExec(t, ui)()
+
+			logsCommand := NewLogsCommand(ui, trellis)
+			code := logsCommand.Run(tc.args)
+
+			if code != tc.code {
+				t.Errorf("%s - actual code %d expected to be %d", tc.name, code, tc.code)
+			}
+
+			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+
+			for _, out := range tc.out {
+				if !strings.Contains(combined, out) {
+					t.Errorf("%s - actual output %q expected to contain %q", tc.name, combined, out)
+				}
+			}
+		})
+	}
+}
+
+func TestLogsHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	switch os.Args[3] {
+	case "ssh":
+		fmt.Fprintf(os.Stdout, "nginx log")
+		os.Exit(0)
+	case "tail":
+		os.Exit(0)
+	default:
+		t.Fatalf("unexpected command %s", os.Args[3])
+	}
+}

--- a/cmd/ssh_test.go
+++ b/cmd/ssh_test.go
@@ -68,7 +68,7 @@ func TestSshRunValidations(t *testing.T) {
 			defer MockUiExec(t, ui)()
 
 			trellis := trellis.NewMockTrellis(tc.projectDetected)
-			sshCommand := &SshCommand{ui, trellis}
+			sshCommand := NewSshCommand(ui, trellis)
 
 			code := sshCommand.Run(tc.args)
 
@@ -114,7 +114,7 @@ func TestSshRun(t *testing.T) {
 			ui := cli.NewMockUi()
 			defer MockUiExec(t, ui)()
 
-			sshCommand := &SshCommand{ui, trellis}
+			sshCommand := NewSshCommand(ui, trellis)
 			code := sshCommand.Run(tc.args)
 
 			if code != tc.code {

--- a/command/testing.go
+++ b/command/testing.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"testing"
 )
 
 func MockExecCommand(stdout io.Writer, stderr io.Writer) func(command string, args []string) *exec.Cmd {
@@ -12,19 +11,10 @@ func MockExecCommand(stdout io.Writer, stderr io.Writer) func(command string, ar
 		cs := []string{"-test.run=TestHelperProcess", "--", command}
 		cs = append(cs, args...)
 		cmd := exec.Command(os.Args[0], cs...)
+
 		cmd.Stdout = stdout
 		cmd.Stderr = stderr
 		cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
 		return cmd
-	}
-}
-
-func MockExec(t *testing.T, stdout io.Writer, stderr io.Writer) func() {
-	t.Helper()
-
-	Mock(MockExecCommand(stdout, stderr))
-
-	return func() {
-		Restore()
 	}
 }

--- a/main.go
+++ b/main.go
@@ -118,6 +118,9 @@ func main() {
 		"key generate": func() (cli.Command, error) {
 			return cmd.NewKeyGenerateCommand(ui, trellis), nil
 		},
+		"logs": func() (cli.Command, error) {
+			return cmd.NewLogsCommand(ui, trellis), nil
+		},
 		"new": func() (cli.Command, error) {
 			return cmd.NewNewCommand(ui, trellis, c.Version), nil
 		},
@@ -134,7 +137,7 @@ func main() {
 			return &cmd.ShellInitCommand{ui}, nil
 		},
 		"ssh": func() (cli.Command, error) {
-			return &cmd.SshCommand{ui, trellis}, nil
+			return cmd.NewSshCommand(ui, trellis), nil
 		},
 		"up": func() (cli.Command, error) {
 			return cmd.NewUpCommand(ui, trellis), nil

--- a/trellis/ssh.go
+++ b/trellis/ssh.go
@@ -1,0 +1,19 @@
+package trellis
+
+import (
+	"fmt"
+)
+
+func (t *Trellis) SshHost(environment string, siteName string, user string) string {
+	host := t.SiteFromEnvironmentAndName(environment, siteName).MainHost()
+
+	if environment == "development" {
+		user = "vagrant"
+	} else {
+		if user == "" {
+			user = "admin"
+		}
+	}
+
+	return fmt.Sprintf("%s@%s", user, host)
+}


### PR DESCRIPTION
Closes #5

```plain
Usage: trellis logs [options] ENVIRONMENT [SITE]

Tails the Nginx log files for an environment.

Automatically integrates with https://goaccess.io/ when the --goaccess option is used.

View production logs:

  $ trellis logs production

View access logs only:

  $ trellis logs --access production

View error logs only:

  $ trellis logs --error production

View logs in goaccess:

  $ trellis logs --goaccess production

Pass flags to goaccess:

  $ trellis logs --goaccess-flags="-a -m" production

View the last 50 log lines (-n corresponds to tail's -n option):

  $ trellis logs -n 50 production

Arguments:
  ENVIRONMENT Name of environment (ie: production)
  SITE        Name of site (ie: example.com)
  
Options:
      --access          Show access logs only
      --error           Show error logs only
  -g, --goaccess        Uses goaccess as the log viewer instead of tail
      --goaccess-flags  Flags to pass to the goaccess command (in quotes)
  -n, --number          Location (number lines) corresponding to tail's '-n' argument
  -h, --help            Show this help
```