### PR TITLE
Add VM management via Lima

### DIFF
--- a/app_paths/app_paths.go
+++ b/app_paths/app_paths.go
@@ -15,7 +15,11 @@ const (
 	xdgDataHome      = "XDG_DATA_HOME"
 )
 
-// Config path precedence: TRELLIS_CONFIG_DIR, XDG_CONFIG_HOME, AppData (windows only), HOME.
+// Config path precedence:
+// 1. TRELLIS_CONFIG_DIR
+// 2. XDG_CONFIG_HOME
+// 3. AppData (windows only)
+// 4. HOME
 func ConfigDir() string {
 	var path string
 
@@ -37,7 +41,10 @@ func ConfigPath(path string) string {
 	return filepath.Join(ConfigDir(), path)
 }
 
-// Cache path precedence: XDG_CACHE_HOME, LocalAppData (windows only), HOME.
+// Cache path precedence:
+// 1. XDG_CACHE_HOME
+// 2. LocalAppData (windows only)
+// 3. HOME
 func CacheDir() string {
 	var path string
 	if a := os.Getenv(xdgCacheHome); a != "" {
@@ -47,6 +54,23 @@ func CacheDir() string {
 	} else {
 		c, _ := os.UserHomeDir()
 		path = filepath.Join(c, ".local", "state", "trellis")
+	}
+	return path
+}
+
+// Data path precedence:
+// 1. XDG_DATA_HOME
+// 2. LocalAppData (windows only)
+// 3. HOME
+func DataDir() string {
+	var path string
+	if a := os.Getenv(xdgDataHome); a != "" {
+		path = filepath.Join(a, "trellis")
+	} else if b := os.Getenv(localAppData); runtime.GOOS == "windows" && b != "" {
+		path = filepath.Join(b, "Trellis CLI")
+	} else {
+		c, _ := os.UserHomeDir()
+		path = filepath.Join(c, ".local", "share", "trellis")
 	}
 	return path
 }

--- a/cmd/vm_delete.go
+++ b/cmd/vm_delete.go
@@ -1,0 +1,137 @@
+package cmd
+
+import (
+	"flag"
+	"strings"
+
+	"github.com/manifoldco/promptui"
+	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
+	"github.com/roots/trellis-cli/lima"
+	"github.com/roots/trellis-cli/trellis"
+)
+
+type VmDeleteCommand struct {
+	UI      cli.Ui
+	Trellis *trellis.Trellis
+	flags   *flag.FlagSet
+	force   bool
+}
+
+func NewVmDeleteCommand(ui cli.Ui, trellis *trellis.Trellis) *VmDeleteCommand {
+	c := &VmDeleteCommand{UI: ui, Trellis: trellis}
+	c.init()
+	return c
+}
+
+func (c *VmDeleteCommand) init() {
+	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+	c.flags.Usage = func() { c.UI.Info(c.Help()) }
+	c.flags.BoolVar(&c.force, "force", false, "Delete VM without confirmation.")
+}
+
+func (c *VmDeleteCommand) Run(args []string) int {
+	if err := c.Trellis.LoadProject(); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	c.Trellis.CheckVirtualenv(c.UI)
+
+	if err := c.flags.Parse(args); err != nil {
+		return 1
+	}
+
+	args = c.flags.Args()
+
+	commandArgumentValidator := &CommandArgumentValidator{required: 0, optional: 0}
+	commandArgumentErr := commandArgumentValidator.validate(args)
+	if commandArgumentErr != nil {
+		c.UI.Error(commandArgumentErr.Error())
+		c.UI.Output(c.Help())
+		return 1
+	}
+
+	siteName, err := c.Trellis.FindSiteNameFromEnvironment("development", "")
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	manager, err := lima.NewManager(c.Trellis)
+	if err != nil {
+		c.UI.Error("Error: " + err.Error())
+		return 1
+	}
+
+	instance, ok := manager.GetInstance(siteName)
+
+	if !ok {
+		c.UI.Info("VM does not exist for this project. Run `trellis vm start` to create it.")
+		return 0
+	}
+
+	if err := instance.Hydrate(false); err != nil {
+		c.UI.Error("Error getting VM info. This is a trellis-cli bug.")
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	if instance.Stopped() {
+		if c.force || c.ConfirmDeletion() {
+			if err := instance.Delete(c.UI); err != nil {
+				c.UI.Error(err.Error())
+				return 1
+			}
+		}
+	} else {
+		c.UI.Error("Error: VM is running. Run `trellis vm stop` to stop it.")
+		return 1
+	}
+
+	return 0
+}
+
+func (c *VmDeleteCommand) Synopsis() string {
+	return "Deletes the development virtual machine."
+}
+
+func (c *VmDeleteCommand) Help() string {
+	helpText := `
+Usage: trellis vm delete [options]
+
+Deletes the development virtual machine.
+VMs must be in a stopped state before they can be deleted.
+
+Delete without prompting for confirmation:
+  $ trellis vm delete --force
+
+Options:
+  --force     Delete VM without confirmation.
+  -h, --help  Show this help
+`
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *VmDeleteCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"--force": complete.PredictNothing,
+	}
+}
+
+func (c *VmDeleteCommand) ConfirmDeletion() bool {
+	prompt := promptui.Prompt{
+		Label:     "Delete virtual machine",
+		IsConfirm: true,
+	}
+
+	_, err := prompt.Run()
+
+	if err != nil {
+		c.UI.Info("Aborted. Not deleting virtual machine.")
+		return false
+	}
+
+	return true
+}

--- a/cmd/vm_delete.go
+++ b/cmd/vm_delete.go
@@ -58,7 +58,7 @@ func (c *VmDeleteCommand) Run(args []string) int {
 		return 1
 	}
 
-	manager, err := lima.NewManager(c.Trellis)
+	manager, err := lima.NewManager(c.Trellis, c.UI)
 	if err != nil {
 		c.UI.Error("Error: " + err.Error())
 		return 1
@@ -71,15 +71,9 @@ func (c *VmDeleteCommand) Run(args []string) int {
 		return 0
 	}
 
-	if err := instance.Hydrate(false); err != nil {
-		c.UI.Error("Error getting VM info. This is a trellis-cli bug.")
-		c.UI.Error(err.Error())
-		return 1
-	}
-
 	if instance.Stopped() {
 		if c.force || c.ConfirmDeletion() {
-			if err := instance.Delete(c.UI); err != nil {
+			if err := manager.DeleteInstance(instance); err != nil {
 				c.UI.Error(err.Error())
 				return 1
 			}

--- a/cmd/vm_delete_test.go
+++ b/cmd/vm_delete_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/cli"
+	"github.com/roots/trellis-cli/trellis"
+)
+
+func TestVmDeleteRunValidations(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
+
+	cases := []struct {
+		name            string
+		projectDetected bool
+		args            []string
+		out             string
+		code            int
+	}{
+		{
+			"no_project",
+			false,
+			nil,
+			"No Trellis project detected",
+			1,
+		},
+		{
+			"too_many_args",
+			true,
+			[]string{"foo"},
+			"Error: too many arguments",
+			1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ui := cli.NewMockUi()
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
+			vmDeleteCommand := NewVmDeleteCommand(ui, trellis)
+
+			code := vmDeleteCommand.Run(tc.args)
+
+			if code != tc.code {
+				t.Errorf("expected code %d to be %d", code, tc.code)
+			}
+
+			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+
+			if !strings.Contains(combined, tc.out) {
+				t.Errorf("expected output %q to contain %q", combined, tc.out)
+			}
+		})
+	}
+}

--- a/cmd/vm_shell.go
+++ b/cmd/vm_shell.go
@@ -27,7 +27,7 @@ func (c *VmShellCommand) Run(args []string) int {
 		return 1
 	}
 
-	manager, err := lima.NewManager(c.Trellis)
+	manager, err := lima.NewManager(c.Trellis, c.UI)
 	if err != nil {
 		c.UI.Error("Error: " + err.Error())
 		return 1
@@ -40,16 +40,10 @@ func (c *VmShellCommand) Run(args []string) int {
 		return 0
 	}
 
-	if err := instance.Hydrate(false); err != nil {
-		c.UI.Error("Error getting VM info. This is a trellis-cli bug.")
-		c.UI.Error(err.Error())
-		return 1
-	}
-
 	if instance.Stopped() {
 		c.UI.Info("VM is stopped. Run `trellis vm start` to start it.")
 	} else {
-		if err := instance.Shell(args); err != nil {
+		if err := manager.OpenShell(instance, args); err != nil {
 			c.UI.Error(err.Error())
 			return 1
 		}

--- a/cmd/vm_shell.go
+++ b/cmd/vm_shell.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/mitchellh/cli"
+	"github.com/roots/trellis-cli/lima"
+	"github.com/roots/trellis-cli/trellis"
+)
+
+type VmShellCommand struct {
+	UI      cli.Ui
+	Trellis *trellis.Trellis
+}
+
+func (c *VmShellCommand) Run(args []string) int {
+	if err := c.Trellis.LoadProject(); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	c.Trellis.CheckVirtualenv(c.UI)
+
+	siteName, err := c.Trellis.FindSiteNameFromEnvironment("development", "")
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	manager, err := lima.NewManager(c.Trellis)
+	if err != nil {
+		c.UI.Error("Error: " + err.Error())
+		return 1
+	}
+
+	instance, ok := manager.GetInstance(siteName)
+
+	if !ok {
+		c.UI.Info("VM does not exist for this project. Run `trellis vm start` to create it.")
+		return 0
+	}
+
+	if err := instance.Hydrate(false); err != nil {
+		c.UI.Error("Error getting VM info. This is a trellis-cli bug.")
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	if instance.Stopped() {
+		c.UI.Info("VM is stopped. Run `trellis vm start` to start it.")
+	} else {
+		if err := instance.Shell(args); err != nil {
+			c.UI.Error(err.Error())
+			return 1
+		}
+	}
+
+	return 0
+}
+
+func (c *VmShellCommand) Synopsis() string {
+	return "Executes shell in the VM"
+}
+
+func (c *VmShellCommand) Help() string {
+	helpText := `
+Usage: trellis vm shell [options] [COMMAND]
+
+Executes shell in the development virtual machine.
+
+Run an optional command from the VM shell:
+
+  $ trellis vm shell whoami
+
+Arguments:
+  COMMAND  Command to execute
+
+Options:
+  -h, --help show this help
+`
+
+	return strings.TrimSpace(helpText)
+}

--- a/cmd/vm_start.go
+++ b/cmd/vm_start.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/mitchellh/cli"
+	"github.com/roots/trellis-cli/lima"
+	"github.com/roots/trellis-cli/trellis"
+)
+
+type VmStartCommand struct {
+	UI      cli.Ui
+	Trellis *trellis.Trellis
+	flags   *flag.FlagSet
+}
+
+func NewVmStartCommand(ui cli.Ui, trellis *trellis.Trellis) *VmStartCommand {
+	c := &VmStartCommand{UI: ui, Trellis: trellis}
+	c.init()
+	return c
+}
+
+func (c *VmStartCommand) init() {
+	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+	c.flags.Usage = func() { c.UI.Info(c.Help()) }
+}
+
+func (c *VmStartCommand) Run(args []string) int {
+	if err := c.Trellis.LoadProject(); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	c.Trellis.CheckVirtualenv(c.UI)
+
+	if err := c.flags.Parse(args); err != nil {
+		return 1
+	}
+
+	args = c.flags.Args()
+
+	commandArgumentValidator := &CommandArgumentValidator{required: 0, optional: 0}
+	commandArgumentErr := commandArgumentValidator.validate(args)
+	if commandArgumentErr != nil {
+		c.UI.Error(commandArgumentErr.Error())
+		c.UI.Output(c.Help())
+		return 1
+	}
+
+	siteName, err := c.Trellis.FindSiteNameFromEnvironment("development", "")
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	manager, err := lima.NewManager(c.Trellis)
+	if err != nil {
+		c.UI.Error("Error: " + err.Error())
+		return 1
+	}
+
+	if err := lima.Installed(); err != nil {
+		c.UI.Error(err.Error())
+		c.UI.Error("Install or upgrade Lima to continue:")
+		c.UI.Error("\n  brew install lima\n")
+		c.UI.Error("See https://github.com/lima-vm/lima#getting-started for manual installation options")
+		return 1
+	}
+
+	instance := manager.NewInstance(siteName)
+	existingInstance, ok := manager.GetInstance(siteName)
+
+	if ok {
+		instance = existingInstance
+
+		if instance.Running() {
+			c.UI.Info(fmt.Sprintf("%s VM already running", color.GreenString("[✓]")))
+		} else {
+			if err := instance.Start(c.UI); err != nil {
+				c.UI.Error("Error starting virtual machine.")
+				c.UI.Error(err.Error())
+				return 1
+			}
+		}
+
+		if err := instance.Hydrate(true); err != nil {
+			c.UI.Error("Error getting VM info. This is a trellis-cli bug.")
+			c.UI.Error(err.Error())
+			return 1
+		}
+
+		if err = c.writeFiles(manager, instance); err != nil {
+			c.UI.Error(err.Error())
+			return 1
+		}
+
+		return 0
+	}
+
+	c.UI.Info("Creating new VM...")
+	if err := instance.Create(); err != nil {
+		c.UI.Error("Error creating VM.")
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	if err := instance.Hydrate(true); err != nil {
+		c.UI.Error("Error getting VM info. This is a trellis-cli bug.")
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	if err = c.writeFiles(manager, instance); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	c.UI.Info("\nProvisioning VM...")
+
+	provisionCmd := NewProvisionCommand(c.UI, c.Trellis)
+	return provisionCmd.Run([]string{"development"})
+}
+
+func (c *VmStartCommand) Synopsis() string {
+	return "Starts a development virtual machine."
+}
+
+func (c *VmStartCommand) Help() string {
+	helpText := `
+Usage: trellis vm start [options]
+
+Starts a development virtual machine.
+If a VM doesn't exist yet, it will be created. If a VM already exists, it will be started.
+
+Note: VM management (under the 'trellis vm' subcommands) is currently only available for macOS Ventura (13.0) and later.
+Lima (https://lima-vm.io/) is the underlying VM manager which requires macOS's new virtualization framework.
+
+Options:
+  -h, --help show this help
+`
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *VmStartCommand) writeFiles(manager *lima.Manager, instance lima.Instance) error {
+	if err := instance.CreateInventoryFile(); err != nil {
+		return err
+	}
+
+	if err := manager.HostsResolver.AddHosts(instance.Name, &instance); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/vm_start_test.go
+++ b/cmd/vm_start_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/cli"
+	"github.com/roots/trellis-cli/trellis"
+)
+
+func TestVmStartRunValidations(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
+
+	cases := []struct {
+		name            string
+		projectDetected bool
+		args            []string
+		out             string
+		code            int
+	}{
+		{
+			"no_project",
+			false,
+			nil,
+			"No Trellis project detected",
+			1,
+		},
+		{
+			"too_many_args",
+			true,
+			[]string{"foo"},
+			"Error: too many arguments",
+			1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ui := cli.NewMockUi()
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
+			vmStartCommand := NewVmStartCommand(ui, trellis)
+
+			code := vmStartCommand.Run(tc.args)
+
+			if code != tc.code {
+				t.Errorf("expected code %d to be %d", code, tc.code)
+			}
+
+			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+
+			if !strings.Contains(combined, tc.out) {
+				t.Errorf("expected output %q to contain %q", combined, tc.out)
+			}
+		})
+	}
+}

--- a/cmd/vm_stop.go
+++ b/cmd/vm_stop.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/mitchellh/cli"
+	"github.com/roots/trellis-cli/lima"
+	"github.com/roots/trellis-cli/trellis"
+)
+
+type VmStopCommand struct {
+	UI      cli.Ui
+	Trellis *trellis.Trellis
+	flags   *flag.FlagSet
+}
+
+func NewVmStopCommand(ui cli.Ui, trellis *trellis.Trellis) *VmStopCommand {
+	c := &VmStopCommand{UI: ui, Trellis: trellis}
+	c.init()
+	return c
+}
+
+func (c *VmStopCommand) init() {
+	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+	c.flags.Usage = func() { c.UI.Info(c.Help()) }
+}
+
+func (c *VmStopCommand) Run(args []string) int {
+	if err := c.Trellis.LoadProject(); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	c.Trellis.CheckVirtualenv(c.UI)
+
+	if err := c.flags.Parse(args); err != nil {
+		return 1
+	}
+
+	args = c.flags.Args()
+
+	commandArgumentValidator := &CommandArgumentValidator{required: 0, optional: 0}
+	commandArgumentErr := commandArgumentValidator.validate(args)
+	if commandArgumentErr != nil {
+		c.UI.Error(commandArgumentErr.Error())
+		c.UI.Output(c.Help())
+		return 1
+	}
+
+	siteName, err := c.Trellis.FindSiteNameFromEnvironment("development", "")
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	manager, err := lima.NewManager(c.Trellis)
+	if err != nil {
+		c.UI.Error("Error: " + err.Error())
+		return 1
+	}
+
+	instance, ok := manager.GetInstance(siteName)
+
+	if !ok {
+		c.UI.Info("VM does not exist for this project. Run `trellis vm start` to create it.")
+		return 0
+	}
+
+	if err := instance.Hydrate(false); err != nil {
+		c.UI.Error("Error getting VM info. This is a trellis-cli bug.")
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	if instance.Stopped() {
+		c.UI.Info(fmt.Sprintf("%s VM already stopped", color.GreenString("[✓]")))
+		return 0
+	} else {
+		if err := instance.Stop(c.UI); err != nil {
+			c.UI.Error("Error stopping VM")
+			c.UI.Error(err.Error())
+			return 1
+		}
+	}
+
+	if err = manager.HostsResolver.RemoveHosts(instance.Name, &instance); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	return 0
+}
+
+func (c *VmStopCommand) Synopsis() string {
+	return "Stops the development virtual machine."
+}
+
+func (c *VmStopCommand) Help() string {
+	helpText := `
+Usage: trellis vm stop [options]
+
+Stops the development virtual machine.
+
+Options:
+  -h, --help show this help
+`
+
+	return strings.TrimSpace(helpText)
+}

--- a/cmd/vm_stop.go
+++ b/cmd/vm_stop.go
@@ -56,7 +56,7 @@ func (c *VmStopCommand) Run(args []string) int {
 		return 1
 	}
 
-	manager, err := lima.NewManager(c.Trellis)
+	manager, err := lima.NewManager(c.Trellis, c.UI)
 	if err != nil {
 		c.UI.Error("Error: " + err.Error())
 		return 1
@@ -66,29 +66,16 @@ func (c *VmStopCommand) Run(args []string) int {
 
 	if !ok {
 		c.UI.Info("VM does not exist for this project. Run `trellis vm start` to create it.")
-		return 0
-	}
-
-	if err := instance.Hydrate(false); err != nil {
-		c.UI.Error("Error getting VM info. This is a trellis-cli bug.")
-		c.UI.Error(err.Error())
-		return 1
-	}
-
-	if instance.Stopped() {
-		c.UI.Info(fmt.Sprintf("%s VM already stopped", color.GreenString("[✓]")))
-		return 0
 	} else {
-		if err := instance.Stop(c.UI); err != nil {
-			c.UI.Error("Error stopping VM")
-			c.UI.Error(err.Error())
-			return 1
+		if instance.Stopped() {
+			c.UI.Info(fmt.Sprintf("%s VM already stopped", color.GreenString("[✓]")))
+		} else {
+			if err := manager.StopInstance(instance); err != nil {
+				c.UI.Error("Error stopping VM")
+				c.UI.Error(err.Error())
+				return 1
+			}
 		}
-	}
-
-	if err = manager.HostsResolver.RemoveHosts(instance.Name, &instance); err != nil {
-		c.UI.Error(err.Error())
-		return 1
 	}
 
 	return 0

--- a/cmd/vm_stop_test.go
+++ b/cmd/vm_stop_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/cli"
+	"github.com/roots/trellis-cli/trellis"
+)
+
+func TestVmStopRunValidations(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
+
+	cases := []struct {
+		name            string
+		projectDetected bool
+		args            []string
+		out             string
+		code            int
+	}{
+		{
+			"no_project",
+			false,
+			nil,
+			"No Trellis project detected",
+			1,
+		},
+		{
+			"too_many_args",
+			true,
+			[]string{"foo"},
+			"Error: too many arguments",
+			1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ui := cli.NewMockUi()
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
+			vmStopCommand := NewVmStopCommand(ui, trellis)
+
+			code := vmStopCommand.Run(tc.args)
+
+			if code != tc.code {
+				t.Errorf("expected code %d to be %d", code, tc.code)
+			}
+
+			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+
+			if !strings.Contains(combined, tc.out) {
+				t.Errorf("expected output %q to contain %q", combined, tc.out)
+			}
+		})
+	}
+}

--- a/cmd/vm_sudoers.go
+++ b/cmd/vm_sudoers.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mitchellh/cli"
+	"github.com/roots/trellis-cli/lima"
+	"github.com/roots/trellis-cli/trellis"
+)
+
+type VmSudoersCommand struct {
+	UI      cli.Ui
+	Trellis *trellis.Trellis
+}
+
+func (c *VmSudoersCommand) Run(args []string) int {
+	if err := c.Trellis.LoadProject(); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	c.Trellis.CheckVirtualenv(c.UI)
+
+	commandArgumentValidator := &CommandArgumentValidator{required: 0, optional: 0}
+	commandArgumentErr := commandArgumentValidator.validate(args)
+	if commandArgumentErr != nil {
+		c.UI.Error(commandArgumentErr.Error())
+		c.UI.Output(c.Help())
+		return 1
+	}
+
+	hostResolver := lima.NewHostsFileResolver([]string{})
+	cmd := hostResolver.SudoersCommand()
+
+	c.UI.Info(fmt.Sprintf("%%staff ALL=(root:wheel) NOPASSWD:NOSETENV: %s", strings.Join(cmd, " ")))
+
+	return 0
+}
+
+func (c *VmSudoersCommand) Synopsis() string {
+	return "Generates sudoers content for passwordless updating of /etc/hosts"
+}
+
+func (c *VmSudoersCommand) Help() string {
+	helpText := `
+Usage: trellis vm sudoers [options]
+
+Generates the content of the /etc/sudoers.d/trellis file.
+This allows trellis-cli to update your /etc/hosts file without having to enter your sudo password.
+
+The content is written to stdout, NOT to the file. This command must not run as the root as shown below.
+
+$ trellis vm sudoers | sudo tee /etc/sudoers.d/trellis
+
+Options:
+  -h, --help show this help
+`
+
+	return strings.TrimSpace(helpText)
+}

--- a/cmd/vm_sudoers_test.go
+++ b/cmd/vm_sudoers_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/cli"
+	"github.com/roots/trellis-cli/trellis"
+)
+
+func TestVmSudoersRunValidations(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
+
+	cases := []struct {
+		name            string
+		projectDetected bool
+		args            []string
+		out             string
+		code            int
+	}{
+		{
+			"no_project",
+			false,
+			nil,
+			"No Trellis project detected",
+			1,
+		},
+		{
+			"too_many_args",
+			true,
+			[]string{"foo"},
+			"Error: too many arguments",
+			1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ui := cli.NewMockUi()
+			trellis := trellis.NewMockTrellis(tc.projectDetected)
+			vmSudoersCommand := &VmSudoersCommand{ui, trellis}
+
+			code := vmSudoersCommand.Run(tc.args)
+
+			if code != tc.code {
+				t.Errorf("expected code %d to be %d", code, tc.code)
+			}
+
+			combined := ui.OutputWriter.String() + ui.ErrorWriter.String()
+
+			if !strings.Contains(combined, tc.out) {
+				t.Errorf("expected output %q to contain %q", combined, tc.out)
+			}
+		})
+	}
+}

--- a/command/testing.go
+++ b/command/testing.go
@@ -1,10 +1,21 @@
 package command
 
 import (
+	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"strings"
+	"testing"
 )
+
+type MockCommand struct {
+	Command  string   `json:"command"`
+	Args     []string `json:"args"`
+	Output   string   `json:"output"`
+	ExitCode int      `json:"exit_code"`
+}
 
 func MockExecCommand(stdout io.Writer, stderr io.Writer) func(command string, args []string) *exec.Cmd {
 	return func(command string, args []string) *exec.Cmd {
@@ -17,4 +28,65 @@ func MockExecCommand(stdout io.Writer, stderr io.Writer) func(command string, ar
 		cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
 		return cmd
 	}
+}
+
+func MockExecCommands(t *testing.T, commands []MockCommand) func() {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+
+	serializedCommands, err := json.Marshal(commands)
+	if err != nil {
+		t.Fatalf("error serializing commands: %s", err)
+	}
+
+	mockExecCommand := func(command string, args []string) *exec.Cmd {
+		cs := []string{"-test.run=TestCommandHelperProcess", "--", command}
+		cs = append(cs, args...)
+		cmd := exec.Command(os.Args[0], cs...)
+		cmd.Env = []string{
+			"GO_WANT_HELPER_PROCESS=1", fmt.Sprintf("GO_TEST_HELPER_TMP_PATH=%s", tmpDir),
+			"GO_TEST_HELPER_COMMANDS=" + string(serializedCommands),
+		}
+		return cmd
+	}
+
+	Mock(mockExecCommand)
+
+	return func() {
+		Restore()
+	}
+}
+
+func CommandHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	commands := []MockCommand{}
+	err := json.Unmarshal([]byte(os.Getenv("GO_TEST_HELPER_COMMANDS")), &commands)
+	if err != nil {
+		t.Fatalf("error unmarshaling commands: %s", err)
+	}
+
+	command := strings.Join(os.Args[3:len(os.Args)], " ")
+
+	commandExecuted := MockCommand{}
+	commandFound := false
+
+	for _, cmd := range commands {
+		execCmd := exec.Command(cmd.Command, cmd.Args...)
+		if execCmd.String() == command {
+			commandExecuted = cmd
+			commandFound = true
+			break
+		}
+	}
+
+	if !commandFound {
+		t.Fatalf("command not found: %s\nmocked commands: %v", command, commands)
+	}
+
+	fmt.Fprintf(os.Stdout, commandExecuted.Output)
+	os.Exit(commandExecuted.ExitCode)
 }

--- a/lima/files/config.yml
+++ b/lima/files/config.yml
@@ -1,0 +1,20 @@
+vmType: "vz"
+images:
+{{ range $image := .Images -}}
+- location: {{ $image.Location }}
+  arch: {{ $image.Arch }}
+{{ end }}
+mounts:
+{{ range $siteName, $site := .Sites -}}
+- location: {{ $site.AbsLocalPath }}
+  mountPoint: /srv/www/{{ $siteName }}/current
+  writable: true
+{{ end }}
+mountType: "virtiofs"
+networks:
+- vzNAT: true
+portForwards:
+- guestPort: 80
+  hostPort: {{ .HttpForwardPort }}
+containerd:
+  user: false

--- a/lima/files/config.yml
+++ b/lima/files/config.yml
@@ -1,6 +1,6 @@
 vmType: "vz"
 images:
-{{ range $image := .Images -}}
+{{ range $image := .Config.Images -}}
 - location: {{ $image.Location }}
   arch: {{ $image.Arch }}
 {{ end }}
@@ -14,7 +14,9 @@ mountType: "virtiofs"
 networks:
 - vzNAT: true
 portForwards:
-- guestPort: 80
-  hostPort: {{ .HttpForwardPort }}
+{{ range $port := .Config.PortForwards -}}
+- guestPort: {{ $port.GuestPort}}
+  hostPort: {{ $port.HostPort }}
+{{ end }}
 containerd:
   user: false

--- a/lima/files/inventory.txt
+++ b/lima/files/inventory.txt
@@ -1,0 +1,7 @@
+default ansible_host=127.0.0.1 ansible_port={{ .SshLocalPort }} ansible_user={{ .Username }} ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+
+[development]
+default
+
+[web]
+default

--- a/lima/hosts_resolver.go
+++ b/lima/hosts_resolver.go
@@ -1,0 +1,123 @@
+package lima
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/roots/trellis-cli/app_paths"
+	"github.com/roots/trellis-cli/command"
+)
+
+var (
+	HostsRemoveErr = errors.New("Error removing hosts")
+	HostsAddErr    = errors.New("Error adding hosts")
+)
+
+type HostsResolver interface {
+	AddHosts(name string, n Networkable) error
+	RemoveHosts(name string, n Networkable) error
+}
+
+type HostsFileResolver struct {
+	Hosts        []string
+	hostsPath    string
+	tmpHostsPath string
+}
+
+func NewHostsResolver(resolverType string, hosts []string) (resolver HostsResolver, err error) {
+	switch resolverType {
+	case "hosts_file":
+		return NewHostsFileResolver(hosts), nil
+	default:
+		return nil, fmt.Errorf("Unknown hosts resolver type: %s", resolverType)
+	}
+}
+
+func NewHostsFileResolver(hosts []string) *HostsFileResolver {
+	return &HostsFileResolver{
+		Hosts:        hosts,
+		hostsPath:    "/etc/hosts",
+		tmpHostsPath: filepath.Join(app_paths.DataDir(), "hosts"),
+	}
+}
+
+func (h *HostsFileResolver) AddHosts(name string, n Networkable) error {
+	content, err := h.addHostsContent(name, n)
+	if err != nil {
+		return fmt.Errorf("%w: %v.\nThis is probably a trellis-cli bug; please report it.", HostsAddErr, err)
+	}
+
+	return h.writeHostsFile(content)
+}
+
+func (h *HostsFileResolver) RemoveHosts(name string, n Networkable) error {
+	content, err := h.removeHostsContent(name, n)
+	if err != nil {
+		return fmt.Errorf("%w: %v.\nThis is probably a trellis-cli bug; please report it.", HostsRemoveErr, err)
+	}
+
+	return h.writeHostsFile(content)
+}
+
+func (h *HostsFileResolver) addHostsContent(name string, n Networkable) (content []byte, err error) {
+	content, err = h.removeHostsContent(name, n)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	instanceHosts, err := h.generateHosts(name, n)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	content = append(content, []byte(instanceHosts)...)
+	return content, nil
+}
+
+func (h *HostsFileResolver) SudoersCommand() []string {
+	return []string{"/bin/cp", h.tmpHostsPath, h.hostsPath}
+}
+
+func (h *HostsFileResolver) removeHostsContent(name string, n Networkable) (content []byte, err error) {
+	header := fmt.Sprintf("## trellis-start-%s", name)
+	footer := fmt.Sprintf("## trellis-end-%s", name)
+
+	re := regexp.MustCompile(fmt.Sprintf(`%s([\s\S]*)%s\n`, header, footer))
+	hostsContent, err := os.ReadFile(h.hostsPath)
+	if err != nil {
+		return []byte{}, fmt.Errorf("Error reading %s file: %v", h.hostsPath, err)
+	}
+
+	hostsContent = re.ReplaceAll(hostsContent, []byte{})
+	return hostsContent, nil
+}
+
+func (h *HostsFileResolver) writeHostsFile(content []byte) error {
+	if err := os.WriteFile(h.tmpHostsPath, content, 0644); err != nil {
+		return err
+	}
+
+	fmt.Printf("\nUpdating %s file (sudo may be required, see `trellis vm sudoers` for more details)\n", h.hostsPath)
+
+	return command.WithOptions(
+		command.WithTermOutput(),
+	).Cmd("sudo", h.SudoersCommand()).Run()
+}
+
+func (h *HostsFileResolver) generateHosts(name string, n Networkable) (string, error) {
+	ip, err := n.IP()
+	if err != nil {
+		return "", err
+	}
+
+	content := fmt.Sprintf(`## trellis-start-%s
+%s %s
+## trellis-end-%s
+`, name, ip, strings.Join(h.Hosts, " "), name)
+
+	return content, nil
+}

--- a/lima/hosts_resolver_test.go
+++ b/lima/hosts_resolver_test.go
@@ -1,0 +1,409 @@
+package lima
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type MockInstance struct {
+	Name string
+}
+
+func (m *MockInstance) HttpHost() string {
+	return "http://127.0.0.1:8080"
+}
+
+func (m *MockInstance) IP() (string, error) {
+	return "192.168.2.1", nil
+}
+
+func TestRemoveHostsContent(t *testing.T) {
+	tempDir := t.TempDir()
+	hostsPath := filepath.Join(tempDir, "hosts")
+	hosts := []string{"example.test", "www.example.test"}
+
+	h := HostsFileResolver{
+		Hosts:        hosts,
+		hostsPath:    filepath.Join(tempDir, "hosts"),
+		tmpHostsPath: filepath.Join(tempDir, "hosts.tmp"),
+	}
+
+	instance := &MockInstance{Name: "foo-bar"}
+
+	cases := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{
+			"no_trellis_block",
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+255.255.255.255	broadcasthost
+::1             localhost
+`,
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+255.255.255.255	broadcasthost
+::1             localhost
+`,
+		},
+		{
+			"trellis_block_end_of_file",
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+255.255.255.255	broadcasthost
+::1             localhost
+## trellis-start-foo-bar
+192.168.2.1 example.test www.example.test
+## trellis-end-foo-bar
+`,
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+255.255.255.255	broadcasthost
+::1             localhost
+`,
+		},
+		{
+			"trellis_block_middle_of_file",
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+## trellis-start-foo-bar
+192.168.2.1 example.test www.example.test
+## trellis-end-foo-bar
+255.255.255.255	broadcasthost
+::1             localhost
+`,
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+255.255.255.255	broadcasthost
+::1             localhost
+`,
+		},
+		{
+			"trellis_block_multiple_lines",
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+## trellis-start-foo-bar
+192.168.2.1 example.test www.example.test
+192.168.2.1 new.example.test old.example.test
+## trellis-end-foo-bar
+255.255.255.255	broadcasthost
+::1             localhost
+`,
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+255.255.255.255	broadcasthost
+::1             localhost
+`,
+		},
+		{
+			"trellis_block_different_instance",
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+255.255.255.255	broadcasthost
+::1             localhost
+## trellis-start-nope
+192.168.2.1 example.test www.example.test
+## trellis-end-nope
+`,
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+255.255.255.255	broadcasthost
+::1             localhost
+## trellis-start-nope
+192.168.2.1 example.test www.example.test
+## trellis-end-nope
+`,
+		},
+		{
+			"trellis_block_multiple_instances",
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+255.255.255.255	broadcasthost
+::1             localhost
+## trellis-start-foo-bar
+192.168.2.1 example.test www.example.test
+## trellis-end-foo-bar
+## trellis-start-nope
+192.168.2.1 example.test www.example.test
+## trellis-end-nope
+`,
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+255.255.255.255	broadcasthost
+::1             localhost
+## trellis-start-nope
+192.168.2.1 example.test www.example.test
+## trellis-end-nope
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := os.WriteFile(hostsPath, []byte(tc.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			content, err := h.removeHostsContent(instance.Name, instance)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if string(content) != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, string(content))
+			}
+		})
+	}
+}
+
+func TestAddHostsContent(t *testing.T) {
+	tempDir := t.TempDir()
+	hostsPath := filepath.Join(tempDir, "hosts")
+	hosts := []string{"example.test", "www.example.test"}
+
+	h := HostsFileResolver{
+		Hosts:        hosts,
+		hostsPath:    filepath.Join(tempDir, "hosts"),
+		tmpHostsPath: filepath.Join(tempDir, "hosts.tmp"),
+	}
+
+	instance := &MockInstance{Name: "foo-bar"}
+
+	cases := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		{
+			"no_trellis_block",
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+255.255.255.255	broadcasthost
+::1             localhost
+`,
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+255.255.255.255	broadcasthost
+::1             localhost
+## trellis-start-foo-bar
+192.168.2.1 example.test www.example.test
+## trellis-end-foo-bar
+`,
+		},
+		{
+			"trellis_block_end_of_file",
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+255.255.255.255	broadcasthost
+::1             localhost
+## trellis-start-foo-bar
+192.168.99.99 example.test www.example.test
+## trellis-end-foo-bar
+`,
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+255.255.255.255	broadcasthost
+::1             localhost
+## trellis-start-foo-bar
+192.168.2.1 example.test www.example.test
+## trellis-end-foo-bar
+`,
+		},
+		{
+			"trellis_block_middle_of_file",
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+## trellis-start-foo-bar
+192.168.2.1 example.test www.example.test
+## trellis-end-foo-bar
+255.255.255.255	broadcasthost
+::1             localhost
+`,
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+255.255.255.255	broadcasthost
+::1             localhost
+## trellis-start-foo-bar
+192.168.2.1 example.test www.example.test
+## trellis-end-foo-bar
+`,
+		},
+		{
+			"trellis_block_different_instance",
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+255.255.255.255	broadcasthost
+::1             localhost
+## trellis-start-nope
+192.168.2.1 example.test www.example.test
+## trellis-end-nope
+`,
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+255.255.255.255	broadcasthost
+::1             localhost
+## trellis-start-nope
+192.168.2.1 example.test www.example.test
+## trellis-end-nope
+## trellis-start-foo-bar
+192.168.2.1 example.test www.example.test
+## trellis-end-foo-bar
+`,
+		},
+		{
+			"trellis_block_multiple_instances",
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+255.255.255.255	broadcasthost
+::1             localhost
+## trellis-start-foo-bar
+192.168.2.1 example.test www.example.test
+## trellis-end-foo-bar
+## trellis-start-nope
+192.168.2.1 example.test www.example.test
+## trellis-end-nope
+`,
+			`##
+# Host Database
+#
+# localhost is used to configure the loopback interface
+# when the system is booting.  Do not change this entry.
+##
+127.0.0.1	localhost
+255.255.255.255	broadcasthost
+::1             localhost
+## trellis-start-nope
+192.168.2.1 example.test www.example.test
+## trellis-end-nope
+## trellis-start-foo-bar
+192.168.2.1 example.test www.example.test
+## trellis-end-foo-bar
+`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := os.WriteFile(hostsPath, []byte(tc.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			content, err := h.addHostsContent(instance.Name, instance)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if string(content) != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, string(content))
+			}
+		})
+	}
+}

--- a/lima/hosts_resolver_test.go
+++ b/lima/hosts_resolver_test.go
@@ -10,10 +10,6 @@ type MockInstance struct {
 	Name string
 }
 
-func (m *MockInstance) HttpHost() string {
-	return "http://127.0.0.1:8080"
-}
-
 func (m *MockInstance) IP() (string, error) {
 	return "192.168.2.1", nil
 }

--- a/lima/install.go
+++ b/lima/install.go
@@ -1,0 +1,36 @@
+package lima
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+
+	"github.com/mcuadros/go-version"
+	"github.com/roots/trellis-cli/command"
+)
+
+const (
+	VersionRequired = ">= 0.14.0"
+)
+
+func Installed() error {
+	if _, err := exec.LookPath("limactl"); err != nil {
+		return fmt.Errorf("Lima is not installed.")
+	}
+
+	output, err := command.Cmd("limactl", []string{"-v"}).Output()
+	if err != nil {
+		return fmt.Errorf("Could get determine the version of Lima.")
+	}
+
+	re := regexp.MustCompile(`.*([0-9]+\.[0-9]+\.[0-9]+(-alpha|beta)?)`)
+	v := re.FindStringSubmatch(string(output))
+	constraint := version.NewConstrainGroupFromString(VersionRequired)
+	matched := constraint.Match(v[1])
+
+	if !matched {
+		return fmt.Errorf("Lima version %s does not satisfy required version (%s).", v[1], VersionRequired)
+	}
+
+	return nil
+}

--- a/lima/lima.go
+++ b/lima/lima.go
@@ -1,0 +1,271 @@
+package lima
+
+import (
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"text/template"
+
+	"github.com/mitchellh/cli"
+	"github.com/roots/trellis-cli/command"
+	"github.com/roots/trellis-cli/trellis"
+	"gopkg.in/yaml.v2"
+)
+
+//go:embed files/config.yml
+var ConfigTemplate string
+
+//go:embed files/inventory.txt
+var inventoryTemplate string
+
+var (
+	ConfigErr    = errors.New("Could not write Lima config file")
+	HydrationErr = errors.New("Could not fetch Lima instance data")
+	IpErr        = errors.New("Could not determine IP address for VM instance")
+)
+
+type PortForward struct {
+	GuestPort int `yaml:"guestPort"`
+	HostPort  int `yaml:"hostPort"`
+}
+
+type Image struct {
+	Location string `yaml:"location"`
+	Arch     string `yaml:"arch"`
+}
+
+type Config struct {
+	Images       []Image       `yaml:"images"`
+	PortForwards []PortForward `yaml:"portForwards"`
+}
+
+type Networkable interface {
+	HttpHost() string
+	IP() (string, error)
+}
+
+type Instance struct {
+	ConfigPath      string
+	ConfigFile      string
+	Sites           map[string]*trellis.Site
+	Name            string `json:"name"`
+	Status          string `json:"status"`
+	Dir             string `json:"dir"`
+	Arch            string `json:"arch"`
+	Cpus            int    `json:"cpus"`
+	Memory          int    `json:"memory"`
+	Disk            int    `json:"disk"`
+	SshLocalPort    int    `json:"sshLocalPort"`
+	HttpForwardPort int
+	Images          []Image
+	Username        string
+}
+
+func (i *Instance) Create() error {
+	httpForwardPort, err := findFreeTCPLocalPort()
+	if err != nil {
+		return fmt.Errorf("Could not find a local free port for HTTP forwarding: %v", err)
+	}
+
+	i.HttpForwardPort = httpForwardPort
+
+	if err := i.CreateConfig(); err != nil {
+		return err
+	}
+
+	args := []string{
+		"start",
+		"--name=" + i.Name,
+		"--tty=false",
+		i.ConfigFile,
+	}
+
+	return command.WithOptions(
+		command.WithTermOutput(),
+	).Cmd("limactl", args).Run()
+}
+
+func (i *Instance) CreateConfig() error {
+	tpl := template.Must(template.New("lima").Parse(ConfigTemplate))
+
+	file, err := os.Create(i.ConfigFile)
+	if err != nil {
+		return fmt.Errorf("%v: %w", ConfigErr, err)
+	}
+
+	err = tpl.Execute(file, i)
+	if err != nil {
+		return fmt.Errorf("%v: %w", ConfigErr, err)
+	}
+
+	return nil
+}
+
+func (i *Instance) CreateInventoryFile() error {
+	tpl := template.Must(template.New("lima").Parse(inventoryTemplate))
+
+	file, err := os.Create(filepath.Join(i.ConfigPath, "inventory"))
+	if err != nil {
+		return fmt.Errorf("Could not create Ansible inventory file: %v", err)
+	}
+
+	err = tpl.Execute(file, i)
+	if err != nil {
+		return fmt.Errorf("Could not template Ansible inventory file: %v", err)
+	}
+
+	return nil
+}
+
+func (i *Instance) Delete(ui cli.Ui) error {
+	return command.WithOptions(
+		command.WithTermOutput(),
+		command.WithLogging(ui),
+	).Cmd("limactl", []string{"delete", i.Name}).Run()
+}
+
+/*
+Gets the IP address of the instance using the output of `ip route`:
+  default via 192.168.64.1 proto dhcp src 192.168.64.2 metric 100
+  192.168.64.0/24 proto kernel scope link src 192.168.64.2
+  192.168.64.1 proto dhcp scope link src 192.168.64.2 metric 100
+*/
+func (i *Instance) IP() (ip string, err error) {
+	output, err := command.Cmd(
+		"limactl",
+		[]string{"shell", "--workdir", "/", i.Name, "ip", "route", "show", "dev", "lima0"},
+	).CombinedOutput()
+
+	if err != nil {
+		return "", fmt.Errorf("%w: %v\n%s", IpErr, err, string(output))
+	}
+
+	re := regexp.MustCompile(`default via .* src ([0-9\.]+)`)
+	matches := re.FindStringSubmatch(string(output))
+	if len(matches) < 2 {
+		return "", fmt.Errorf("%w: no IP address could be matched in the ip route output\n%s", IpErr, string(output))
+	}
+
+	ip = matches[1]
+
+	return ip, nil
+}
+
+func (i *Instance) Running() bool {
+	return i.Status == "Running"
+}
+
+func (i *Instance) Shell(commandArgs []string) error {
+	args := []string{"shell", i.Name}
+	args = append(args, commandArgs...)
+
+	return command.WithOptions(
+		command.WithTermOutput(),
+	).Cmd("limactl", args).Run()
+}
+
+func (i *Instance) Start(ui cli.Ui) error {
+	return command.WithOptions(
+		command.WithTermOutput(),
+		command.WithLogging(ui),
+	).Cmd("limactl", []string{"start", "--tty=false", i.Name}).Run()
+}
+
+func (i *Instance) Stop(ui cli.Ui) error {
+	return command.WithOptions(
+		command.WithTermOutput(),
+		command.WithLogging(ui),
+	).Cmd("limactl", []string{"stop", i.Name}).Run()
+}
+
+func (i *Instance) Stopped() bool {
+	return i.Status == "Stopped"
+}
+
+func (i *Instance) HttpHost() string {
+	return fmt.Sprintf("http://127.0.0.1:%d", i.HttpForwardPort)
+}
+
+// TODO: replace when new `lima inspect` command is available
+func (i *Instance) Hydrate(hydrateUser bool) (err error) {
+	if err = i.hydrateFromConfig(); err != nil {
+		return err
+	}
+	if err = i.hydrateFromLima(); err != nil {
+		return err
+	}
+
+	if hydrateUser {
+		user, err := i.getUsername()
+		if err == nil {
+			i.Username = string(user)
+		}
+	}
+
+	return nil
+}
+
+func (i *Instance) getUsername() ([]byte, error) {
+	user, err := command.Cmd("limactl", []string{"shell", i.Name, "whoami"}).Output()
+	return user, err
+}
+
+func (i *Instance) hydrateFromConfig() error {
+	config := &Config{}
+
+	configYaml, err := os.ReadFile(i.ConfigFile)
+	if err != nil {
+		return nil
+	}
+
+	if err = yaml.Unmarshal(configYaml, config); err != nil {
+		return fmt.Errorf("%v: %w", HydrationErr, err)
+	}
+
+	i.HttpForwardPort = config.PortForwards[0].HostPort
+
+	return nil
+}
+
+func (i *Instance) hydrateFromLima() error {
+	output, err := command.Cmd("limactl", []string{"list", "--json", i.Name}).Output()
+	if err != nil {
+		return fmt.Errorf("%v: %w", HydrationErr, err)
+	}
+
+	data := strings.Split(string(output), "\n")[0]
+
+	if err = json.Unmarshal([]byte(data), i); err != nil {
+		return fmt.Errorf("%v: %w", HydrationErr, err)
+	}
+
+	return nil
+}
+
+func findFreeTCPLocalPort() (int, error) {
+	lAddr0, err := net.ResolveTCPAddr("tcp4", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	l, err := net.ListenTCP("tcp4", lAddr0)
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	lAddr := l.Addr()
+	lTCPAddr, ok := lAddr.(*net.TCPAddr)
+	if !ok {
+		return 0, fmt.Errorf("expected *net.TCPAddr, got %v", lAddr)
+	}
+	port := lTCPAddr.Port
+	if port <= 0 {
+		return 0, fmt.Errorf("unexpected port %d", port)
+	}
+	return port, nil
+}

--- a/lima/lima_test.go
+++ b/lima/lima_test.go
@@ -23,14 +23,21 @@ func TestCreateConfig(t *testing.T) {
 	instance := &Instance{
 		Dir:        dir,
 		ConfigFile: configFile,
-		Images: []Image{
-			{
-				Location: "http://ubuntu.com/focal",
-				Arch:     "aarch64",
+		Config: Config{
+			Images: []Image{
+				{
+					Location: "http://ubuntu.com/focal",
+					Arch:     "aarch64",
+				},
+			},
+			PortForwards: []PortForward{
+				{
+					HostPort:  1234,
+					GuestPort: 80,
+				},
 			},
 		},
-		HttpForwardPort: 1234,
-		Sites:           trellis.Environments["development"].WordPressSites,
+		Sites: trellis.Environments["development"].WordPressSites,
 	}
 
 	err := instance.CreateConfig()
@@ -62,6 +69,7 @@ networks:
 portForwards:
 - guestPort: 80
   hostPort: 1234
+
 containerd:
   user: false
 `, absSitePath)

--- a/lima/lima_test.go
+++ b/lima/lima_test.go
@@ -1,0 +1,143 @@
+package lima
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/roots/trellis-cli/command"
+	"github.com/roots/trellis-cli/trellis"
+)
+
+func TestCreateConfig(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
+	trellis := trellis.NewTrellis()
+	if err := trellis.LoadProject(); err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "lima.yaml")
+
+	instance := &Instance{
+		Dir:        dir,
+		ConfigFile: configFile,
+		Images: []Image{
+			{
+				Location: "http://ubuntu.com/focal",
+				Arch:     "aarch64",
+			},
+		},
+		HttpForwardPort: 1234,
+		Sites:           trellis.Environments["development"].WordPressSites,
+	}
+
+	err := instance.CreateConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := os.ReadFile(configFile)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	absSitePath := filepath.Join(trellis.Path, "../site")
+
+	expected := fmt.Sprintf(`vmType: "vz"
+images:
+- location: http://ubuntu.com/focal
+  arch: aarch64
+
+mounts:
+- location: %s
+  mountPoint: /srv/www/example.com/current
+  writable: true
+
+mountType: "virtiofs"
+networks:
+- vzNAT: true
+portForwards:
+- guestPort: 80
+  hostPort: 1234
+containerd:
+  user: false
+`, absSitePath)
+
+	if string(content) != expected {
+		t.Errorf("expected %s\ngot %s", expected, string(content))
+	}
+}
+
+func TestCreateInventoryFile(t *testing.T) {
+	dir := t.TempDir()
+
+	instance := &Instance{
+		Dir:          dir,
+		ConfigPath:   dir,
+		SshLocalPort: 1234,
+		Username:     "dev",
+	}
+
+	err := instance.CreateInventoryFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(instance.ConfigPath, "inventory"))
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `default ansible_host=127.0.0.1 ansible_port=1234 ansible_user=dev ansible_ssh_common_args='-o StrictHostKeyChecking=no'
+
+[development]
+default
+
+[web]
+default
+`
+
+	if string(content) != expected {
+		t.Errorf("expected %s\ngot %s", expected, string(content))
+	}
+}
+
+func TestIP(t *testing.T) {
+	instance := &Instance{
+		Name: "test",
+	}
+
+	mockOutput := `default via 192.168.64.1 proto dhcp src 192.168.64.2 metric 100
+192.168.64.0/24 proto kernel scope link src 192.168.64.2
+192.168.64.1 proto dhcp scope link src 192.168.64.2 metric 100
+`
+	commands := []command.MockCommand{
+		{
+			Command: "limactl",
+			Args: []string{
+				"shell", "--workdir", "/", instance.Name, "ip", "route", "show", "dev", "lima0",
+			},
+			Output: mockOutput,
+		},
+	}
+	defer command.MockExecCommands(t, commands)()
+
+	ip, err := instance.IP()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "192.168.64.2"
+
+	if ip != expected {
+		t.Errorf("expected %s\ngot %s", expected, ip)
+	}
+}
+
+func TestCommandHelperProcess(t *testing.T) {
+	command.CommandHelperProcess(t)
+}

--- a/lima/manager.go
+++ b/lima/manager.go
@@ -1,0 +1,127 @@
+package lima
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mcuadros/go-version"
+	"github.com/roots/trellis-cli/command"
+	"github.com/roots/trellis-cli/trellis"
+)
+
+const (
+	configDir            = "lima"
+	RequiredMacOSVersion = "13.0.0"
+)
+
+var (
+	ConfigPathError    = errors.New("could not create config directory")
+	UnsupportedOSError = errors.New("Unsupported OS or macOS version. The macOS Virtualization Framework requires macOS 13.0 (Ventura) or later.")
+)
+
+type Manager struct {
+	ConfigPath    string
+	Sites         map[string]*trellis.Site
+	HostsResolver HostsResolver
+	trellis       *trellis.Trellis
+}
+
+func NewManager(trellis *trellis.Trellis) (manager *Manager, err error) {
+	macOSVersion, err := getMacOSVersion()
+	if err != nil {
+		return nil, UnsupportedOSError
+	}
+
+	if version.Compare(macOSVersion, RequiredMacOSVersion, "<") {
+		return nil, fmt.Errorf("%w", UnsupportedOSError)
+	}
+
+	limaConfigPath := filepath.Join(trellis.ConfigPath(), configDir)
+
+	hostNames := trellis.Environments["development"].AllHosts()
+	hostsResolver, err := NewHostsResolver(trellis.CliConfig.Vm.HostsResolver, hostNames)
+
+	if err != nil {
+		return nil, err
+	}
+
+	manager = &Manager{
+		ConfigPath:    limaConfigPath,
+		Sites:         trellis.Environments["development"].WordPressSites,
+		HostsResolver: hostsResolver,
+		trellis:       trellis,
+	}
+
+	if err = manager.createConfigPath(); err != nil {
+		return nil, fmt.Errorf("%w: %v", ConfigPathError, err)
+	}
+
+	return manager, nil
+}
+
+func (m *Manager) NewInstance(name string) Instance {
+	name = convertToInstanceName(name)
+	images := []Image{}
+
+	for _, image := range m.trellis.CliConfig.Vm.Images {
+		images = append(images, Image{
+			Location: image.Location,
+			Arch:     image.Arch,
+		})
+	}
+
+	instance := Instance{
+		Name:       name,
+		ConfigPath: m.ConfigPath,
+		ConfigFile: filepath.Join(m.ConfigPath, name+".yml"),
+		Images:     images,
+		Sites:      m.Sites,
+	}
+
+	return instance
+}
+
+func (m *Manager) GetInstance(name string) (Instance, bool) {
+	instances := m.Instances()
+	instance, ok := instances[convertToInstanceName(name)]
+
+	return instance, ok
+}
+
+func (m *Manager) Instances() (instances map[string]Instance) {
+	instances = make(map[string]Instance)
+	output, err := command.Cmd("limactl", []string{"list", "--json"}).Output()
+
+	for _, line := range strings.Split(string(output), "\n") {
+		var instance Instance
+		if err = json.Unmarshal([]byte(line), &instance); err == nil {
+			instances[instance.Name] = instance
+		}
+	}
+
+	return instances
+}
+
+func (m *Manager) createConfigPath() error {
+	return os.MkdirAll(m.ConfigPath, 0755)
+}
+
+func convertToInstanceName(value string) string {
+	return strings.ReplaceAll(value, ".", "-")
+}
+
+func getMacOSVersion() (string, error) {
+	cmd := command.Cmd("sw_vers", []string{"-productVersion"})
+	b, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	verTrimmed := strings.TrimSpace(string(b))
+	version := version.Normalize(verTrimmed)
+	return version, nil
+}

--- a/lima/manager.go
+++ b/lima/manager.go
@@ -4,11 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/mcuadros/go-version"
+	"github.com/mitchellh/cli"
 	"github.com/roots/trellis-cli/command"
 	"github.com/roots/trellis-cli/trellis"
 )
@@ -27,17 +29,15 @@ type Manager struct {
 	ConfigPath    string
 	Sites         map[string]*trellis.Site
 	HostsResolver HostsResolver
+	ui            cli.Ui
 	trellis       *trellis.Trellis
 }
 
-func NewManager(trellis *trellis.Trellis) (manager *Manager, err error) {
-	macOSVersion, err := getMacOSVersion()
-	if err != nil {
-		return nil, UnsupportedOSError
-	}
-
-	if version.Compare(macOSVersion, RequiredMacOSVersion, "<") {
-		return nil, fmt.Errorf("%w", UnsupportedOSError)
+func NewManager(trellis *trellis.Trellis, ui cli.Ui) (manager *Manager, err error) {
+	if os.Getenv("TRELLIS_BYPASS_LIMA_REQUIREMENTS") != "1" {
+		if err := ensureRequirements(); err != nil {
+			return nil, err
+		}
 	}
 
 	limaConfigPath := filepath.Join(trellis.ConfigPath(), configDir)
@@ -54,6 +54,7 @@ func NewManager(trellis *trellis.Trellis) (manager *Manager, err error) {
 		Sites:         trellis.Environments["development"].WordPressSites,
 		HostsResolver: hostsResolver,
 		trellis:       trellis,
+		ui:            ui,
 	}
 
 	if err = manager.createConfigPath(); err != nil {
@@ -63,8 +64,135 @@ func NewManager(trellis *trellis.Trellis) (manager *Manager, err error) {
 	return manager, nil
 }
 
-func (m *Manager) NewInstance(name string) Instance {
-	name = convertToInstanceName(name)
+func (m *Manager) GetInstance(name string) (Instance, bool) {
+	instances := m.Instances()
+	instance, ok := instances[name]
+
+	return instance, ok
+}
+
+func (m *Manager) Instances() (instancesByName map[string]Instance) {
+	instances := []Instance{}
+	instancesByName = make(map[string]Instance)
+
+	output, _ := command.Cmd("limactl", []string{"inspect"}).Output()
+	json.Unmarshal(output, &instances)
+
+	for _, instance := range instances {
+		m.initInstance(&instance)
+		instancesByName[instance.Name] = instance
+	}
+
+	return instancesByName
+}
+
+func (m *Manager) CreateInstance(name string) error {
+	httpForwardPort, err := findFreeTCPLocalPort()
+	if err != nil {
+		return fmt.Errorf("Could not find a local free port for HTTP forwarding: %v", err)
+	}
+
+	instance := m.newInstance(name)
+
+	instance.Config.PortForwards = []PortForward{
+		{GuestPort: 80, HostPort: httpForwardPort},
+	}
+
+	if err := instance.CreateConfig(); err != nil {
+		return err
+	}
+
+	return m.StartInstance(instance)
+}
+
+func (m *Manager) DeleteInstance(instance Instance) error {
+	return command.WithOptions(
+		command.WithTermOutput(),
+		command.WithLogging(m.ui),
+	).Cmd("limactl", []string{"delete", instance.Name}).Run()
+}
+
+// TODO: set working dir to site path?
+func (m *Manager) OpenShell(instance Instance, commandArgs []string) error {
+	args := []string{"shell", instance.Name}
+	args = append(args, commandArgs...)
+
+	return command.WithOptions(
+		command.WithTermOutput(),
+		command.WithLogging(m.ui),
+	).Cmd("limactl", args).Run()
+}
+
+func (m *Manager) StartInstance(instance Instance) error {
+	err := command.WithOptions(
+		command.WithTermOutput(),
+		command.WithLogging(m.ui),
+	).Cmd("limactl", []string{"start", "--tty=false", "--name=" + instance.Name, instance.ConfigFile}).Run()
+
+	if err != nil {
+		return err
+	}
+
+	user, err := instance.getUsername()
+	if err != nil {
+		return fmt.Errorf("Could not get username: %v", err)
+	}
+
+	instance.Username = string(user)
+
+	// Hydrate instance with data from limactl that is only available after starting (mainly the forwarded SSH local port)
+	err = m.hydrateInstance(&instance)
+	if err != nil {
+		return err
+	}
+
+	if err = m.addHosts(instance); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Manager) StopInstance(instance Instance) error {
+	err := command.WithOptions(
+		command.WithTermOutput(),
+		command.WithLogging(m.ui),
+	).Cmd("limactl", []string{"stop", instance.Name}).Run()
+
+	if err != nil {
+		return err
+	}
+
+	if err = m.removeHosts(instance); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Manager) hydrateInstance(instance *Instance) error {
+	i, _ := m.GetInstance(instance.Name)
+	tmpJson, err := json.Marshal(i)
+	if err != nil {
+		return fmt.Errorf("Could not marshal instance: %v\nThis is a trellis-cli bug.", err)
+	}
+	if err = json.Unmarshal(tmpJson, instance); err != nil {
+		return fmt.Errorf("Could not unmarshal instance: %v\nThis is a trellis-cli bug.", err)
+	}
+
+	return nil
+}
+
+func (m *Manager) initInstance(instance *Instance) {
+	instance.ConfigPath = m.ConfigPath
+	instance.ConfigFile = filepath.Join(m.ConfigPath, instance.Name+".yml")
+	instance.Sites = m.Sites
+}
+
+func (m *Manager) newInstance(name string) Instance {
+	instance := Instance{Name: name}
+	m.initInstance(&instance)
+
 	images := []Image{}
 
 	for _, image := range m.trellis.CliConfig.Vm.Images {
@@ -74,44 +202,29 @@ func (m *Manager) NewInstance(name string) Instance {
 		})
 	}
 
-	instance := Instance{
-		Name:       name,
-		ConfigPath: m.ConfigPath,
-		ConfigFile: filepath.Join(m.ConfigPath, name+".yml"),
-		Images:     images,
-		Sites:      m.Sites,
-	}
-
+	config := Config{Images: images}
+	instance.Config = config
 	return instance
-}
-
-func (m *Manager) GetInstance(name string) (Instance, bool) {
-	instances := m.Instances()
-	instance, ok := instances[convertToInstanceName(name)]
-
-	return instance, ok
-}
-
-func (m *Manager) Instances() (instances map[string]Instance) {
-	instances = make(map[string]Instance)
-	output, err := command.Cmd("limactl", []string{"list", "--json"}).Output()
-
-	for _, line := range strings.Split(string(output), "\n") {
-		var instance Instance
-		if err = json.Unmarshal([]byte(line), &instance); err == nil {
-			instances[instance.Name] = instance
-		}
-	}
-
-	return instances
 }
 
 func (m *Manager) createConfigPath() error {
 	return os.MkdirAll(m.ConfigPath, 0755)
 }
 
-func convertToInstanceName(value string) string {
-	return strings.ReplaceAll(value, ".", "-")
+func (m *Manager) addHosts(instance Instance) error {
+	if err := instance.CreateInventoryFile(); err != nil {
+		return err
+	}
+
+	if err := m.HostsResolver.AddHosts(instance.Name, &instance); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Manager) removeHosts(instance Instance) error {
+	return m.HostsResolver.RemoveHosts(instance.Name, &instance)
 }
 
 func getMacOSVersion() (string, error) {
@@ -124,4 +237,48 @@ func getMacOSVersion() (string, error) {
 	verTrimmed := strings.TrimSpace(string(b))
 	version := version.Normalize(verTrimmed)
 	return version, nil
+}
+
+func ensureRequirements() error {
+	macOSVersion, err := getMacOSVersion()
+	if err != nil {
+		return UnsupportedOSError
+	}
+
+	if version.Compare(macOSVersion, RequiredMacOSVersion, "<") {
+		return fmt.Errorf("%w", UnsupportedOSError)
+	}
+
+	if err = Installed(); err != nil {
+		return fmt.Errorf(err.Error() + `
+Install or upgrade Lima to continue:
+
+  brew install lima
+
+See https://github.com/lima-vm/lima#getting-started for manual installation options.`)
+	}
+
+	return nil
+}
+
+func findFreeTCPLocalPort() (int, error) {
+	lAddr0, err := net.ResolveTCPAddr("tcp4", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	l, err := net.ListenTCP("tcp4", lAddr0)
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	lAddr := l.Addr()
+	lTCPAddr, ok := lAddr.(*net.TCPAddr)
+	if !ok {
+		return 0, fmt.Errorf("expected *net.TCPAddr, got %v", lAddr)
+	}
+	port := lTCPAddr.Port
+	if port <= 0 {
+		return 0, fmt.Errorf("unexpected port %d", port)
+	}
+	return port, nil
 }

--- a/lima/manager_test.go
+++ b/lima/manager_test.go
@@ -1,0 +1,135 @@
+package lima
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/roots/trellis-cli/command"
+	"github.com/roots/trellis-cli/trellis"
+)
+
+func TestNewManager(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
+	trellis := trellis.NewTrellis()
+	if err := trellis.LoadProject(); err != nil {
+		t.Fatal(err)
+	}
+
+	commands := []command.MockCommand{
+		{
+			Command: "sw_vers",
+			Args:    []string{"-productVersion"},
+			Output:  `13.0.1`,
+		},
+	}
+	defer command.MockExecCommands(t, commands)()
+
+	_, err := NewManager(trellis)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewManagerUnsupportedOS(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
+	trellis := trellis.NewTrellis()
+	if err := trellis.LoadProject(); err != nil {
+		t.Fatal(err)
+	}
+
+	commands := []command.MockCommand{
+		{
+			Command: "sw_vers",
+			Args:    []string{"-productVersion"},
+			Output:  `12.0.1`,
+		},
+	}
+	defer command.MockExecCommands(t, commands)()
+
+	_, err := NewManager(trellis)
+	if err == nil {
+		t.Fatal(err)
+	}
+
+	expected := "Unsupported OS or macOS version. The macOS Virtualization Framework requires macOS 13.0 (Ventura) or later."
+
+	if err.Error() != expected {
+		t.Errorf("expected error to be %q, got %q", expected, err.Error())
+	}
+}
+
+func TestNewInstance(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
+	trellis := trellis.NewTrellis()
+	if err := trellis.LoadProject(); err != nil {
+		t.Fatal(err)
+	}
+
+	commands := []command.MockCommand{
+		{
+			Command: "sw_vers",
+			Args:    []string{"-productVersion"},
+			Output:  `13.0.1`,
+		},
+	}
+	defer command.MockExecCommands(t, commands)()
+
+	manager, err := NewManager(trellis)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	instance := manager.NewInstance("test")
+
+	if instance.Name != "test" {
+		t.Errorf("expected instance name to be %q, got %q", "test", instance.Name)
+	}
+}
+
+func TestInstances(t *testing.T) {
+	defer trellis.LoadFixtureProject(t)()
+	trellis := trellis.NewTrellis()
+	if err := trellis.LoadProject(); err != nil {
+		t.Fatal(err)
+	}
+
+	instanceName := "test"
+
+	instancesJson := fmt.Sprintf(`{"name":"%s","status":"Running","dir":"/foo/test","vmType":"vz","arch":"aarch64","cpuType":"","cpus":4,"memory":4294967296,"disk":107374182400,"network":[{"vzNAT":true,"macAddress":"52:55:55:6f:d9:e3","interface":"lima0"}],"sshLocalPort":60720,"hostAgentPID":9390,"driverPID":9390}`, instanceName)
+
+	commands := []command.MockCommand{
+		{
+			Command: "sw_vers",
+			Args:    []string{"-productVersion"},
+			Output:  `13.0.1`,
+		},
+		{
+			Command: "limactl",
+			Args:    []string{"list", "--json"},
+			Output:  instancesJson,
+		},
+	}
+
+	defer command.MockExecCommands(t, commands)()
+
+	manager, err := NewManager(trellis)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	instances := manager.Instances()
+
+	if len(instances) != 1 {
+		t.Errorf("expected 1 instance, got %d", len(instances))
+	}
+
+	instance, ok := instances[instanceName]
+
+	if !ok {
+		t.Errorf("expected instance with name %s to be present", instanceName)
+	}
+
+	if instance.Name != instanceName {
+		t.Errorf("expected instance name to be %q, got %q", instanceName, instance.Name)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -35,6 +35,8 @@ func main() {
 	}
 
 	trellis := trellis.NewTrellis()
+
+	// load global CLI config
 	if err := trellis.LoadCliConfig(); err != nil {
 		ui.Error(err.Error())
 		os.Exit(1)
@@ -171,6 +173,27 @@ func main() {
 		},
 		"venv hook": func() (cli.Command, error) {
 			return &cmd.VenvHookCommand{UI: ui, Trellis: trellis}, nil
+		},
+		"vm": func() (cli.Command, error) {
+			return &cmd.NamespaceCommand{
+				HelpText:     "Usage: trellis vm <subcommand> [<args>]",
+				SynopsisText: "Commands for managing development virtual machines",
+			}, nil
+		},
+		"vm delete": func() (cli.Command, error) {
+			return cmd.NewVmDeleteCommand(ui, trellis), nil
+		},
+		"vm shell": func() (cli.Command, error) {
+			return &cmd.VmShellCommand{UI: ui, Trellis: trellis}, nil
+		},
+		"vm start": func() (cli.Command, error) {
+			return cmd.NewVmStartCommand(ui, trellis), nil
+		},
+		"vm stop": func() (cli.Command, error) {
+			return cmd.NewVmStopCommand(ui, trellis), nil
+		},
+		"vm sudoers": func() (cli.Command, error) {
+			return &cmd.VmSudoersCommand{UI: ui, Trellis: trellis}, nil
 		},
 		"xdebug-tunnel": func() (cli.Command, error) {
 			return &cmd.NamespaceCommand{

--- a/trellis/config.go
+++ b/trellis/config.go
@@ -2,19 +2,21 @@ package trellis
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"log"
 	"os"
+	"path/filepath"
 	"sort"
 
 	"github.com/roots/trellis-cli/dns"
 	"github.com/weppos/publicsuffix-go/publicsuffix"
+	"gopkg.in/yaml.v2"
 )
 
 const DefaultSiteName = "example.com"
 
 type Site struct {
 	SiteHosts       []SiteHost             `yaml:"site_hosts"`
+	AbsLocalPath    string                 `yaml:"-"`
 	LocalPath       string                 `yaml:"local_path"`
 	AdminEmail      string                 `yaml:"admin_email,omitempty"`
 	Branch          string                 `yaml:"branch,omitempty"`
@@ -47,6 +49,9 @@ func (t *Trellis) ParseConfig(path string) *Config {
 		log.Fatalln(err)
 	}
 
+	for _, site := range config.WordPressSites {
+		site.AbsLocalPath = filepath.Join(t.Path, site.LocalPath)
+	}
 	return config
 }
 

--- a/trellis/testing.go
+++ b/trellis/testing.go
@@ -23,7 +23,7 @@ func LoadFixtureProject(t *testing.T) func() {
 	err = cmd.Run()
 
 	if err != nil {
-		t.Fatalf("err: %s", err)
+		t.Fatalf("failed to copy trellis fixture project: %s", err)
 	}
 
 	os.Chdir(filepath.Join(tempDir, "trellis"))

--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -37,6 +37,20 @@ var DefaultCliConfig = cli_config.Config{
 	LoadPlugins:             true,
 	Open:                    make(map[string]string),
 	VirtualenvIntegration:   true,
+	Vm: cli_config.VmConfig{
+		Manager:       "lima",
+		HostsResolver: "hosts_file",
+		Images: []cli_config.VmImage{
+			{
+				Location: "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img",
+				Arch:     "x86_64",
+			},
+			{
+				Location: "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-arm64.img",
+				Arch:     "aarch64",
+			},
+		},
+	},
 }
 
 type Trellis struct {


### PR DESCRIPTION
Up until now, trellis-cli had limited integration with Vagrant for managing virtual machines. The `up` and `down` commands exist, but didn't fully wrap the underlying Vagrant usage.

Most of the Vagrant integration is done in Trellis itself, with the CLI just running `vagrant up` for you basically. It was quite limited, and still relied on Vagrant, which is quite slow and heavy for what we need.

This adds full integration for managing virtual machines in development via https://github.com/lima-vm/lima as an alternative to Vagrant. Lima stands for "Linux virtual machines (on macOS, in most cases)" and that's exactly our use case.

Lima isn't just a replacement for Vagrant, it also replaces the VM provider like VirtualBox or Parallels too. Lima supports two ways of running guest machines:

* [QEMU](https://www.qemu.org/)
* macOS Virtualization.Framework ("vz")

For this initial integration, we're only supporting the macOS Virtualization.Framework because it offers near-native performance, and that includes file syncing via `virtiofs`. 

For macOS Ventura (13.0+) users, we'll eventually recommend using trellis-cli's VM feature over Vagrant as the default since it's easier and faster. We'll look into expanding support for Linux users as well depending on performance of the file mounts on the VM.

## Requirements
* Intel or Apple Silicon
* macOS 13 (Ventura)
* Lima >= 0.14

## Usage
There's 5 new commands:

* `trellis vm start`
* `trellis vm stop`
* `trellis vm delete`
* `trellis vm shell`
* `trellis vm sudoers`

Under the hood, those commands wrap equivalent `limactl` features. Just like the previous Vagrant integration, you can always run `limactl` directly to manage your VMs.

For default use cases, `trellis vm start` can be run without any customization first. It will create a new virtual machine (using Lima) from a generated config file (`project/trellis/.trellis/lima/config/<name>.yml`). The site's `local_path` will be automatically mounted on the VM and your `/etc/hosts` file will be updated.

Note: see `trellis vm sudoers -h` for more details on making the `/etc/hosts` updates passwordless. Or just run:
```bash
$ trellis vm sudoers | sudo tee /etc/sudoers.d/trellis
```

## Configuration
Right now configuration options for the VM are limited. The intention is to the most common use cases without any configuration needed.

A trellis-cli config file (global or project level) supports a new `vm` option. The only useful config option right now is `images` (to switch between Ubuntu 20.04 and 22.04 for example). 20.04.

Here's an example of specifying Jammy 22.04 for ARM (`aarch64`) only, since that's what I use):

```yml
# .trellis/cli.yml
vm:
  images:
    - location: https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-arm64.img
      arch: aarch64
```