### PR TITLE
Switch to verbose output when init command is slow

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -4,12 +4,24 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"io"
+	"os"
+	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/mitchellh/cli"
 	"github.com/roots/trellis-cli/command"
 	"github.com/roots/trellis-cli/trellis"
 )
+
+type WrappedIOWriter struct {
+	writer io.Writer
+}
+
+func (w *WrappedIOWriter) Write(p []byte) (n int, err error) {
+	return w.writer.Write(p)
+}
 
 func NewInitCommand(ui cli.Ui, trellis *trellis.Trellis) *InitCommand {
 	c := &InitCommand{UI: ui, Trellis: trellis}
@@ -69,97 +81,33 @@ func (c *InitCommand) Run(args []string) int {
 	}
 
 	if c.force {
-		spinner := NewSpinner(
-			SpinnerCfg{
-				Message:     "Deleting existing virtualenv",
-				FailMessage: "Error deleting virtualenv",
-			},
-		)
-		spinner.Start()
-		err := c.Trellis.Virtualenv.Delete()
-
-		if err != nil {
-			spinner.StopFail()
-			c.UI.Error(err.Error())
+		if err := c.deleteVirtualenv(); err != nil {
 			return 1
 		}
-
-		spinner.Stop()
 	}
 
 	if !c.Trellis.Virtualenv.Initialized() {
-		spinner := NewSpinner(
-			SpinnerCfg{
-				Message:     "Creating virtualenv",
-				FailMessage: "Error creating virtualenv",
-				StopMessage: fmt.Sprintf("Created virtualenv (%s)", c.Trellis.Virtualenv.Path),
-			},
-		)
-
-		spinner.Start()
-		err := c.Trellis.Virtualenv.Create()
-		if err != nil {
-			spinner.StopFail()
-			c.UI.Error(err.Error())
-			c.UI.Error("")
-			c.UI.Error("Project initialization failed due to the error above.")
-			c.UI.Error("")
-			c.UI.Error("trellis-cli tried to create a virtual environment but failed.")
-			c.UI.Error(fmt.Sprintf("  => %s", virtualenvCmd.String()))
-			c.UI.Error("")
-			virtualenvError(c.UI)
+		if err := c.createVirtualenv(virtualenvCmd); err != nil {
 			return 1
 		}
-
-		c.Trellis.VenvInitialized = true
-		spinner.Stop()
 	}
 
-	spinner := NewSpinner(
-		SpinnerCfg{
-			Message:     "Ensure pip is up to date",
-			FailMessage: "Error upgrading pip",
-		},
-	)
-	spinner.Start()
-	pipUpgradeOutput, err := command.Cmd("python3", []string{"-m", "pip", "install", "--upgrade", "pip"}).CombinedOutput()
-
-	if err != nil {
-		spinner.StopFail()
-		c.UI.Error(string(pipUpgradeOutput))
-		return 1
-	}
-	spinner.Stop()
-
-	spinner = NewSpinner(
-		SpinnerCfg{
-			Message:     "Installing dependencies (this can take a minute...)",
-			FailMessage: "Error installing dependencies",
-			StopMessage: "Dependencies installed",
-		},
-	)
-	spinner.Start()
-	pipCmd := command.Cmd("pip", []string{"install", "-r", "requirements.txt"})
-	errorOutput := &bytes.Buffer{}
-	pipCmd.Stderr = errorOutput
-	err = pipCmd.Run()
-
-	if err != nil {
-		spinner.StopFail()
-		c.UI.Error(errorOutput.String())
+	if err := c.upgradePip(); err != nil {
 		return 1
 	}
 
-	spinner.Stop()
+	if err := c.pipInstall(); err != nil {
+		return 1
+	}
 
-	err = c.Trellis.Virtualenv.UpdateBinShebangs("ansible*")
-	if err != nil {
+	if err := c.Trellis.Virtualenv.UpdateBinShebangs("ansible*"); err != nil {
 		c.UI.Error("Error while initializing project in a directory path that contains spaces.")
 		c.UI.Error("Python's virtualenv does not properly handle paths with spaces in them. trellis-cli attempted to automatically fix the bin scripts as a workaround but encountered an error:")
 		c.UI.Error(err.Error())
 		c.UI.Error("As an alternative, you can re-create this project in a path without spaces.")
 		c.UI.Error("Or you can open an issue to let us know: https://github.com/roots/trellis-cli")
 	}
+
 	return 0
 }
 
@@ -211,4 +159,112 @@ func virtualenvError(ui cli.Ui) {
 	ui.Error("     Ubuntu/Debian users (including Windows WSL): venv is not built-in, to install it run `sudo apt-get install python3-pip python3-venv`")
 	ui.Error("")
 	ui.Error("  2. Disable trellis-cli's virtualenv feature, and manage dependencies manually, by changing the 'virtualenv_integration' configuration setting to 'false'.")
+}
+
+func (c *InitCommand) deleteVirtualenv() error {
+	spinner := NewSpinner(
+		SpinnerCfg{
+			Message:     "Deleting existing virtualenv",
+			FailMessage: "Error deleting virtualenv",
+		},
+	)
+	spinner.Start()
+	err := c.Trellis.Virtualenv.Delete()
+
+	if err != nil {
+		spinner.StopFail()
+		c.UI.Error(err.Error())
+		return err
+	}
+
+	spinner.Stop()
+
+	return nil
+}
+
+func (c *InitCommand) createVirtualenv(virtualenvCmd *exec.Cmd) error {
+	spinner := NewSpinner(
+		SpinnerCfg{
+			Message:     "Creating virtualenv",
+			FailMessage: "Error creating virtualenv",
+			StopMessage: fmt.Sprintf("Created virtualenv (%s)", c.Trellis.Virtualenv.Path),
+		},
+	)
+
+	spinner.Start()
+	err := c.Trellis.Virtualenv.Create()
+	if err != nil {
+		spinner.StopFail()
+		c.UI.Error(err.Error())
+		c.UI.Error("")
+		c.UI.Error("Project initialization failed due to the error above.")
+		c.UI.Error("")
+		c.UI.Error("trellis-cli tried to create a virtual environment but failed.")
+		c.UI.Error(fmt.Sprintf("  => %s", virtualenvCmd.String()))
+		c.UI.Error("")
+		virtualenvError(c.UI)
+		return err
+	}
+
+	c.Trellis.VenvInitialized = true
+	spinner.Stop()
+
+	return nil
+}
+
+func (c *InitCommand) upgradePip() error {
+	spinner := NewSpinner(
+		SpinnerCfg{
+			Message:     "Ensure pip is up to date",
+			FailMessage: "Error upgrading pip",
+		},
+	)
+	spinner.Start()
+	pipUpgradeOutput, err := command.Cmd("python3", []string{"-m", "pip", "install", "--upgrade", "pip"}).CombinedOutput()
+
+	if err != nil {
+		spinner.StopFail()
+		c.UI.Error(string(pipUpgradeOutput))
+		return err
+	}
+
+	spinner.Stop()
+	return nil
+}
+
+func (c *InitCommand) pipInstall() error {
+	spinner := NewSpinner(
+		SpinnerCfg{
+			Message:     "Installing dependencies (this can take a minute...)",
+			FailMessage: "Error installing dependencies",
+			StopMessage: "Dependencies installed",
+		},
+	)
+	spinner.Start()
+	pipCmd := command.Cmd("pip", []string{"install", "-r", "requirements.txt"})
+
+	// Wrap pipCmd's Stdout in a custom writer that only displays output once the timer has elapsed.
+	timer := time.NewTimer(30 * time.Second)
+	writer := &WrappedIOWriter{writer: io.Discard}
+	pipCmd.Stdout = writer
+
+	go func() {
+		<-timer.C
+		spinner.Pause()
+		writer.writer = os.Stdout
+		c.UI.Warn("\n\npip install taking longer than expected. Switching to verbose output:\n")
+	}()
+
+	errorOutput := &bytes.Buffer{}
+	pipCmd.Stderr = errorOutput
+	err := pipCmd.Run()
+
+	if err != nil {
+		spinner.StopFail()
+		c.UI.Error(errorOutput.String())
+		return err
+	}
+
+	spinner.Stop()
+	return nil
 }


### PR DESCRIPTION
Fixes #306

The `init` command can be slow during the `pip install` step depending on network connections, first projects, or uncached dependencies. Since the output was hidden behind a spinner, it's not obvious what's happening during these situations.

This will switch to verbose mode showing `pip install`'s stdout to provide more information and a sign of progress most importantly.