### PR TITLE
Fix ssh cmd flags

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -37,6 +37,12 @@ func (c *SshCommand) Run(args []string) int {
 		return 1
 	}
 
+	if err := c.flags.Parse(args); err != nil {
+		return 1
+	}
+
+	args = c.flags.Args()
+
 	commandArgumentValidator := &CommandArgumentValidator{required: 1, optional: 1}
 	commandArgumentErr := commandArgumentValidator.validate(args)
 	if commandArgumentErr != nil {

--- a/cmd/ssh_test.go
+++ b/cmd/ssh_test.go
@@ -107,6 +107,12 @@ func TestSshRun(t *testing.T) {
 			"ssh vagrant@example.test",
 			0,
 		},
+		{
+			"production_with_user_flag",
+			[]string{"-u=web", "production"},
+			"ssh web@example.com",
+			0,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Flags for the ssh command weren't parsed before and effectively ignored/not supported.