### PR TITLE
Add database_app CLI config option

### DIFF
--- a/cli_config/cli_config.go
+++ b/cli_config/cli_config.go
@@ -26,6 +26,7 @@ type VmConfig struct {
 type Config struct {
 	AllowDevelopmentDeploys bool              `yaml:"allow_development_deploys"`
 	AskVaultPass            bool              `yaml:"ask_vault_pass"`
+	DatabaseApp             string            `yaml:"database_app"`
 	CheckForUpdates         bool              `yaml:"check_for_updates"`
 	LoadPlugins             bool              `yaml:"load_plugins"`
 	Open                    map[string]string `yaml:"open"`
@@ -64,6 +65,10 @@ func (c *Config) LoadFile(path string) error {
 
 	if c.Vm.HostsResolver != "hosts_file" {
 		return fmt.Errorf("%w: unsupported value for `vm.hosts_resolver`. Must be one of: hosts_file", InvalidConfigErr)
+	}
+
+	if c.DatabaseApp != "" && c.DatabaseApp != "tableplus" && c.DatabaseApp != "sequel-ace" {
+		return fmt.Errorf("%w: unsupported value for `database_app`. Must be one of: tableplus, sequel-ace", InvalidConfigErr)
 	}
 
 	return nil

--- a/cmd/db_opener_factory.go
+++ b/cmd/db_opener_factory.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/mitchellh/cli"
 )
 
 type DBOpenerFactory struct{}
@@ -11,12 +10,12 @@ type DBOpener interface {
 	Open(c DBCredentials) (err error)
 }
 
-func (f *DBOpenerFactory) Make(app string, ui cli.Ui) (o DBOpener, err error) {
+func (f *DBOpenerFactory) Make(app string) (o DBOpener, err error) {
 	switch app {
 	case "tableplus":
 		return &DBOpenerTableplus{}, nil
 	case "sequel-ace":
-		return &DBOpenerSequelAce{ui: ui}, nil
+		return &DBOpenerSequelAce{}, nil
 	case "sequel-pro":
 		return nil, fmt.Errorf("Sequel Pro is replaced by Sequel Ace. Check the docs for more info: https://docs.roots.io/trellis/master/database-access/")
 	}

--- a/cmd/db_opener_factory_test.go
+++ b/cmd/db_opener_factory_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"github.com/mitchellh/cli"
 	"reflect"
 	"strings"
 	"testing"
@@ -10,7 +9,7 @@ import (
 func TestMakeUnexpected(t *testing.T) {
 	factory := &DBOpenerFactory{}
 
-	_, actualErr := factory.Make("unexpected-app", cli.NewMockUi())
+	_, actualErr := factory.Make("unexpected-app")
 
 	actualErrorMessage := actualErr.Error()
 
@@ -38,7 +37,7 @@ func TestMake(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		actual, actualErr := factory.Make(tc.app, cli.NewMockUi())
+		actual, actualErr := factory.Make(tc.app)
 
 		if actualErr != nil {
 			t.Errorf("expected error %s to be nil", actualErr)

--- a/cmd/db_opener_sequel_ace.go
+++ b/cmd/db_opener_sequel_ace.go
@@ -7,12 +7,10 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/mitchellh/cli"
 	"github.com/roots/trellis-cli/command"
 )
 
 type DBOpenerSequelAce struct {
-	ui cli.Ui
 }
 
 //go:embed files/sequel_ace_spf_template.xml

--- a/cmd/db_opener_sequel_ace_test.go
+++ b/cmd/db_opener_sequel_ace_test.go
@@ -22,9 +22,7 @@ func TestOpen(t *testing.T) {
 	ui := cli.NewMockUi()
 	defer MockUiExec(t, ui)()
 
-	sequelAce := &DBOpenerSequelAce{
-		ui: ui,
-	}
+	sequelAce := &DBOpenerSequelAce{}
 
 	sequelAce.Open(dbCredentials)
 


### PR DESCRIPTION
Lets you set a default database app used in the `db open` command so the `--app` flag doesn't need to be manually set every time.

Also adds `db open` command autocompletion which was missing.