### PR TITLE
Improve name options for vm start

### DIFF
--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -17,11 +17,10 @@ import (
 )
 
 const (
-	ConfigDir   = ".trellis"
-	GlobPattern = "group_vars/*/wordpress_sites.yml"
+	cliConfigFile = "cli.yml"
+	ConfigDir     = ".trellis"
+	GlobPattern   = "group_vars/*/wordpress_sites.yml"
 )
-
-const cliConfigFile = "cli.yml"
 
 type Options struct {
 	Detector  Detector


### PR DESCRIPTION
In some cases, trellis-cli could fail to determine the VM name and would error without any other options.

This provides two options:
1. a new `--name` flag to manually set it
2. a prompt for the name when the default fails