### PR TITLE
Fix default VM name

### DIFF
--- a/cmd/alias.go
+++ b/cmd/alias.go
@@ -119,10 +119,16 @@ func (c *AliasCommand) Run(args []string) int {
 		}
 
 		if !c.skipLocal && c.local == environment {
-			siteName, _ := c.Trellis.FindSiteNameFromEnvironment(environment, "")
-			mainHost := c.Trellis.SiteFromEnvironmentAndName(environment, siteName).MainHost()
+			_, site, err := c.Trellis.MainSiteFromEnvironment(environment)
+
+			if err != nil {
+				spinner.StopFail()
+				c.UI.Error(err.Error())
+				return 1
+			}
+
 			args = append(args, "-e", "include_local_env=true")
-			args = append(args, "-e", "local_hostname_alias="+mainHost)
+			args = append(args, "-e", "local_hostname_alias="+site.MainHost())
 		}
 
 		mockUi := cli.NewMockUi()

--- a/cmd/key_generate.go
+++ b/cmd/key_generate.go
@@ -99,9 +99,9 @@ func (c *KeyGenerateCommand) Run(args []string) int {
 	}
 
 	if c.keyName == "" {
-		siteName, siteNameErr := c.Trellis.FindSiteNameFromEnvironment("development", "")
-		if siteNameErr != nil {
-			c.UI.Error(siteNameErr.Error())
+		siteName, _, siteErr := c.Trellis.MainSiteFromEnvironment("development")
+		if siteErr != nil {
+			c.UI.Error(siteErr.Error())
 			return 1
 		}
 

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -34,14 +34,13 @@ func (c *OpenCommand) Run(args []string) int {
 	var openArgs = []string{}
 
 	if len(args) == 0 {
-		siteName, siteNameErr := c.Trellis.FindSiteNameFromEnvironment("development", "")
-		if siteNameErr != nil {
-			c.UI.Error(siteNameErr.Error())
+		_, site, siteErr := c.Trellis.MainSiteFromEnvironment("development")
+		if siteErr != nil {
+			c.UI.Error(siteErr.Error())
 			return 1
 		}
 
-		url := c.Trellis.SiteFromEnvironmentAndName("development", siteName).MainUrl()
-		openArgs = []string{url}
+		openArgs = []string{site.MainUrl()}
 	} else {
 		value, exists := c.Trellis.CliConfig.Open[args[0]]
 

--- a/cmd/vm_delete.go
+++ b/cmd/vm_delete.go
@@ -51,7 +51,7 @@ func (c *VmDeleteCommand) Run(args []string) int {
 		return 1
 	}
 
-	siteName, err := c.Trellis.FindSiteNameFromEnvironment("development", "")
+	siteName, _, err := c.Trellis.MainSiteFromEnvironment("development")
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/cmd/vm_shell.go
+++ b/cmd/vm_shell.go
@@ -20,7 +20,7 @@ func (c *VmShellCommand) Run(args []string) int {
 
 	c.Trellis.CheckVirtualenv(c.UI)
 
-	siteName, err := c.Trellis.FindSiteNameFromEnvironment("development", "")
+	siteName, _, err := c.Trellis.MainSiteFromEnvironment("development")
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/cmd/vm_start.go
+++ b/cmd/vm_start.go
@@ -49,9 +49,9 @@ func (c *VmStartCommand) Run(args []string) int {
 		return 1
 	}
 
-	siteName, err := c.Trellis.FindSiteNameFromEnvironment("development", "")
+	siteName, _, err := c.Trellis.MainSiteFromEnvironment("development")
 	if err != nil {
-		c.UI.Error(err.Error())
+		c.UI.Error("Error: could not automatically set VM name: " + err.Error())
 		return 1
 	}
 

--- a/cmd/vm_stop.go
+++ b/cmd/vm_stop.go
@@ -47,7 +47,7 @@ func (c *VmStopCommand) Run(args []string) int {
 		return 1
 	}
 
-	siteName, err := c.Trellis.FindSiteNameFromEnvironment("development", "")
+	siteName, _, err := c.Trellis.MainSiteFromEnvironment("development")
 	if err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -265,6 +265,18 @@ func (t *Trellis) FindSiteNameFromEnvironment(environment string, siteNameArg st
 	return "", fmt.Errorf("Error: %s is not a valid site. Valid options are %s", siteNameArg, siteNames)
 }
 
+func (t *Trellis) MainSiteFromEnvironment(environment string) (string, *Site, error) {
+	sites := t.SiteNamesFromEnvironment(environment)
+
+	if len(sites) == 0 {
+		return "", nil, fmt.Errorf("Error: No sites found in %s environment", environment)
+	}
+
+	name := sites[0]
+
+	return name, t.Environments[environment].WordPressSites[name], nil
+}
+
 func (t *Trellis) getDefaultSiteNameFromEnvironment(environment string) (siteName string, err error) {
 	sites := t.SiteNamesFromEnvironment(environment)
 

--- a/trellis/trellis_test.go
+++ b/trellis/trellis_test.go
@@ -239,6 +239,33 @@ func TestSiteFromEnvironmentAndName(t *testing.T) {
 	}
 }
 
+func TestMainSiteFromEnvironment(t *testing.T) {
+	expected := &Site{}
+
+	environments := make(map[string]*Config)
+	environments["a"] = &Config{
+		WordPressSites: make(map[string]*Site),
+	}
+
+	environments["a"].WordPressSites["a1"] = expected
+	environments["a"].WordPressSites["a2"] = &Site{}
+	environments["a"].WordPressSites["a3"] = &Site{}
+
+	trellis := Trellis{
+		Environments: environments,
+	}
+
+	name, actual, _ := trellis.MainSiteFromEnvironment("a")
+
+	if name != "a1" {
+		t.Errorf("expected a1 got %s", name)
+	}
+
+	if actual != expected {
+		t.Error("expected site not returned")
+	}
+}
+
 func TestActivateProjectForProjects(t *testing.T) {
 	defer LoadFixtureProject(t)()
 


### PR DESCRIPTION
Always uses the first/main site name as the default instead of erroring if there's multiple dev sites.