### PR TITLE
Lima config updates

### DIFF
--- a/pkg/lima/files/config.yml
+++ b/pkg/lima/files/config.yml
@@ -15,11 +15,13 @@ mounts:
 mountType: "virtiofs"
 networks:
 - vzNAT: true
+{{ if .Config.PortForwards }}
 portForwards:
 {{ range $port := .Config.PortForwards -}}
 - guestPort: {{ $port.GuestPort}}
   hostPort: {{ $port.HostPort }}
 {{ end }}
+{{ end -}}
 containerd:
   user: false
 provision:

--- a/pkg/lima/instance.go
+++ b/pkg/lima/instance.go
@@ -91,6 +91,15 @@ func (i *Instance) CreateInventoryFile() error {
 	return nil
 }
 
+func (i *Instance) DeleteConfig() error {
+	err := os.Remove(i.ConfigFile)
+	if err != nil {
+		return fmt.Errorf("Could not delete config file: %v", err)
+	}
+
+	return nil
+}
+
 /*
 Gets the IP address of the instance using the output of `ip route`:
   default via 192.168.64.1 proto dhcp src 192.168.64.2 metric 100

--- a/pkg/lima/instance_test.go
+++ b/pkg/lima/instance_test.go
@@ -68,6 +68,7 @@ mounts:
 mountType: "virtiofs"
 networks:
 - vzNAT: true
+
 portForwards:
 - guestPort: 80
   hostPort: 1234

--- a/pkg/lima/manager.go
+++ b/pkg/lima/manager.go
@@ -105,10 +105,20 @@ func (m *Manager) DeleteInstance(name string) error {
 	}
 
 	if instance.Stopped() {
-		return command.WithOptions(
+		err := command.WithOptions(
 			command.WithTermOutput(),
 			command.WithLogging(m.ui),
 		).Cmd("limactl", []string{"delete", instance.Name}).Run()
+
+		if err != nil {
+			return err
+		}
+
+		if err := instance.DeleteConfig(); err != nil {
+			return err
+		}
+
+		return nil
 	} else {
 		return fmt.Errorf("Error: VM is running. Run `trellis vm stop` to stop it.")
 	}


### PR DESCRIPTION
* Only output `portForwards` if any exist
* Delete VM config on `vm delete`