### PR TITLE
Set development inventory file based on VM

### DIFF
--- a/cmd/alias.go
+++ b/cmd/alias.go
@@ -110,6 +110,8 @@ func (c *AliasCommand) Run(args []string) int {
 
 	defer c.aliasPlaybook.DumpFiles()()
 
+	devInventory := findDevInventory(c.Trellis, c.UI)
+
 	for _, environment := range envsToAlias {
 		playbook := ansible.Playbook{
 			Name:    "alias.yml",
@@ -130,6 +132,7 @@ func (c *AliasCommand) Run(args []string) int {
 				return 1
 			}
 
+			playbook.SetInventory(devInventory)
 			playbook.AddExtraVar("include_local_env", "true")
 			playbook.AddExtraVar("local_hostname_alias", site.MainHost())
 		}

--- a/cmd/db_open.go
+++ b/cmd/db_open.go
@@ -118,6 +118,10 @@ func (c *DBOpenCommand) Run(args []string) int {
 		},
 	}
 
+	if environment == "development" {
+		playbook.SetInventory(findDevInventory(c.Trellis, c.UI))
+	}
+
 	mockUi := cli.NewMockUi()
 	dumpDbCredentials := command.WithOptions(
 		command.WithUiOutput(mockUi),

--- a/cmd/dot_env.go
+++ b/cmd/dot_env.go
@@ -75,6 +75,10 @@ func (c *DotEnvCommand) Run(args []string) int {
 		Env:  environment,
 	}
 
+	if environment == "development" {
+		playbook.SetInventory(findDevInventory(c.Trellis, c.UI))
+	}
+
 	mockUi := cli.NewMockUi()
 	dotenv := command.WithOptions(
 		command.WithUiOutput(mockUi),
@@ -98,7 +102,8 @@ func (c *DotEnvCommand) Help() string {
 	helpText := `
 Usage: trellis dotenv [options] [ENVIRONMENT=development]
 
-Template .env files to local system
+Template .env file to local system (defaults to development environment)
+
 Template the production .env file:
 
   $ trellis dotenv production

--- a/cmd/vm.go
+++ b/cmd/vm.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"runtime"
 
 	"github.com/mitchellh/cli"
@@ -9,6 +11,8 @@ import (
 	"github.com/roots/trellis-cli/pkg/vm"
 	"github.com/roots/trellis-cli/trellis"
 )
+
+const VagrantInventoryFilePath string = ".vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory"
 
 func newVmManager(trellis *trellis.Trellis, ui cli.Ui) (manager vm.Manager, err error) {
 	switch trellis.CliConfig.Vm.Manager {
@@ -26,4 +30,21 @@ func newVmManager(trellis *trellis.Trellis, ui cli.Ui) (manager vm.Manager, err 
 	}
 
 	return nil, fmt.Errorf("VM manager not found")
+}
+
+func findDevInventory(trellis *trellis.Trellis, ui cli.Ui) string {
+	manager, managerErr := newVmManager(trellis, ui)
+
+	if managerErr == nil {
+		_, vmInventoryErr := os.Stat(manager.InventoryPath())
+		if vmInventoryErr == nil {
+			return manager.InventoryPath()
+		}
+	}
+
+	if _, vagrantInventoryErr := os.Stat(filepath.Join(trellis.Path, VagrantInventoryFilePath)); vagrantInventoryErr == nil {
+		return VagrantInventoryFilePath
+	}
+
+	return ""
 }

--- a/pkg/ansible/playbook.go
+++ b/pkg/ansible/playbook.go
@@ -33,7 +33,10 @@ func (p *Playbook) AddExtraVars(extraVars string) *Playbook {
 }
 
 func (p *Playbook) SetInventory(path string) *Playbook {
-	p.AddArg("--inventory-file", path)
+	if path != "" {
+		p.AddArg("--inventory-file", path)
+	}
+
 	return p
 }
 


### PR DESCRIPTION
Automatically sets Ansible's inventory (`--inventory-file` option) in development based on the type of VM detected.

trellis-cli's Lima based VM gets priority over Vagrant by default if both inventory files are detected.