### PR TITLE
Fix virtualenv_integration config setting

### DIFF
--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -114,7 +114,7 @@ func (t *Trellis) CreateConfigDir() error {
 }
 
 func (t *Trellis) CheckVirtualenv(ui cli.Ui) {
-	if !t.venvWarned && !t.VenvInitialized {
+	if t.CliConfig.VirtualenvIntegration && !t.venvWarned && !t.VenvInitialized {
 		ui.Warn(`
 WARNING: This project has not been initialized with trellis-cli and may not work as expected.
 


### PR DESCRIPTION
Setting `virtualenv_integration: false` still resulted in the venv warning message being displayed even though the error message says it would disable it.

Reported in https://discourse.roots.io/t/introducing-lima-to-trellis-for-faster-local-development/24928/37?u=swalkinshaw