### PR TITLE
Add workdir support to `vm shell`

### DIFF
--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -134,10 +134,10 @@ Arguments:
   ENVIRONMENT Name of environment (ie: production)
   
 Options:
-      --extra-vars  (multiple) set additional variables as key=value or YAML/JSON, if filename prepend with @
-      --tags        (multiple) only run roles and tasks tagged with these values
+      --extra-vars  (multiple) Set additional variables as key=value or YAML/JSON, if filename prepend with @
+      --tags        (multiple) Only run roles and tasks tagged with these values
       --verbose     Enable Ansible's verbose mode
-  -h, --help        show this help
+  -h, --help        Show this help
 `
 
 	return strings.TrimSpace(helpText)

--- a/cmd/vm_shell.go
+++ b/cmd/vm_shell.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"flag"
 	"strings"
 
 	"github.com/mitchellh/cli"
@@ -10,6 +11,20 @@ import (
 type VmShellCommand struct {
 	UI      cli.Ui
 	Trellis *trellis.Trellis
+	flags   *flag.FlagSet
+	workdir string
+}
+
+func NewVmShellCommand(ui cli.Ui, trellis *trellis.Trellis) *VmShellCommand {
+	c := &VmShellCommand{UI: ui, Trellis: trellis}
+	c.init()
+	return c
+}
+
+func (c *VmShellCommand) init() {
+	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+	c.flags.Usage = func() { c.UI.Info(c.Help()) }
+	c.flags.StringVar(&c.workdir, "workdir", "", "Working directory to start the shell in.")
 }
 
 func (c *VmShellCommand) Run(args []string) int {
@@ -19,6 +34,12 @@ func (c *VmShellCommand) Run(args []string) int {
 	}
 
 	c.Trellis.CheckVirtualenv(c.UI)
+
+	if err := c.flags.Parse(args); err != nil {
+		return 1
+	}
+
+	args = c.flags.Args()
 
 	siteName, _, err := c.Trellis.MainSiteFromEnvironment("development")
 	if err != nil {
@@ -32,7 +53,14 @@ func (c *VmShellCommand) Run(args []string) int {
 		return 1
 	}
 
-	if err := manager.OpenShell(siteName, args); err != nil {
+	if c.workdir == "" {
+		c.workdir = "/srv/www/" + siteName + "/current"
+	}
+
+	shellArgs := []string{"--workdir", c.workdir}
+	shellArgs = append(shellArgs, args...)
+
+	if err := manager.OpenShell(siteName, c.workdir, args); err != nil {
 		c.UI.Error(err.Error())
 		return 1
 	}
@@ -46,19 +74,28 @@ func (c *VmShellCommand) Synopsis() string {
 
 func (c *VmShellCommand) Help() string {
 	helpText := `
-Usage: trellis vm shell [options] [COMMAND]
+Usage: trellis vm shell [options] [-- COMMAND]
 
 Executes shell in the development virtual machine.
 
-Run an optional command from the VM shell:
+Any arguments after the -- separator will be passed to the shell:
 
-  $ trellis vm shell whoami
+  $ trellis vm shell -- whoami
+
+Start shell in a specific working directory:
+
+  $ trellis vm shell --workdir /srv/www/example.com/shared
+
+Run a command in a specific working directory:
+
+  $ trellis vm shell --workdir /srv/www/example.com/shared -- ls
 
 Arguments:
   COMMAND  Command to execute
 
 Options:
-  -h, --help show this help
+      --workdir  Working directory to start the shell in.
+  -h, --help     Show this help
 `
 
 	return strings.TrimSpace(helpText)

--- a/main.go
+++ b/main.go
@@ -187,7 +187,7 @@ func main() {
 			return cmd.NewVmDeleteCommand(ui, trellis), nil
 		},
 		"vm shell": func() (cli.Command, error) {
-			return &cmd.VmShellCommand{UI: ui, Trellis: trellis}, nil
+			return cmd.NewVmShellCommand(ui, trellis), nil
 		},
 		"vm start": func() (cli.Command, error) {
 			return cmd.NewVmStartCommand(ui, trellis), nil

--- a/pkg/lima/manager.go
+++ b/pkg/lima/manager.go
@@ -124,8 +124,7 @@ func (m *Manager) DeleteInstance(name string) error {
 	}
 }
 
-// TODO: set working dir to site path?
-func (m *Manager) OpenShell(name string, commandArgs []string) error {
+func (m *Manager) OpenShell(name string, dir string, commandArgs []string) error {
 	instance, ok := m.GetInstance(name)
 
 	if !ok {
@@ -138,7 +137,7 @@ func (m *Manager) OpenShell(name string, commandArgs []string) error {
 		return nil
 	}
 
-	args := []string{"shell", instance.Name}
+	args := []string{"shell", "--workdir", dir, instance.Name}
 	args = append(args, commandArgs...)
 
 	return command.WithOptions(

--- a/pkg/vm/testing.go
+++ b/pkg/vm/testing.go
@@ -39,6 +39,6 @@ func (m *MockVmManager) StopInstance(name string) error {
 	return nil
 }
 
-func (m *MockVmManager) OpenShell(name string, commandArgs []string) error {
+func (m *MockVmManager) OpenShell(name string, dir string, commandArgs []string) error {
 	return nil
 }

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -14,5 +14,5 @@ type Manager interface {
 	InventoryPath() string
 	StartInstance(name string) error
 	StopInstance(name string) error
-	OpenShell(name string, commandArgs []string) error
+	OpenShell(name string, dir string, commandArgs []string) error
 }


### PR DESCRIPTION
Fixes #377

Sets the default working directory for `vm shell` to the project's _main_ site (eg: `/srv/www/example.com/current`). The 
default can be overridden with the `--workdir` flag.

cc @robrecord 