### PR TITLE
Support new trellis.cli.yml config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,15 +157,17 @@ Supported commands so far:
 There are three ways to set configuration settings for trellis-cli and they are
 loaded in this order of precedence:
 
-1. global config
-2. project config
-3. env variables
+1. global config (`$HOME/.config/trellis/cli.yml`)
+2. project config (`trellis.cli.yml`)
+3. project config local override (`trellis.cli.local.yml`)
+4. env variables
 
 The global CLI config (defaults to `$HOME/.config/trellis/cli.yml`)
 and will be loaded first (if it exists).
 
 Next, if a project is detected, the project CLI config will be loaded if it
-exists at `.trellis/cli.yml`.
+exists at `trellis.cli.yml`. A Git ignored local override config is also
+supported at `trellis.cli.local.yml`.
 
 Finally, env variables prefixed with `TRELLIS_` will be used as
 overrides if they match a supported configuration setting. The prefix will be

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -45,7 +45,7 @@ func (c *OpenCommand) Run(args []string) int {
 		value, exists := c.Trellis.CliConfig.Open[args[0]]
 
 		if !exists {
-			c.UI.Error(fmt.Sprintf("Error: shortcut '%s' does not exist. Check your .trellis/cli.yml config file.", args[0]))
+			c.UI.Error(fmt.Sprintf("Error: shortcut '%s' does not exist in your CLI config file.", args[0]))
 			c.UI.Error(fmt.Sprintf("Valid shortcuts are: %s", strings.Join(openNames(c.Trellis.CliConfig.Open), ", ")))
 			return 1
 		}
@@ -87,7 +87,7 @@ Opens user-defined URLs (and more) which can act as shortcuts/bookmarks specific
 
 Without any arguments provided, this defaults to opening the main site's development canonical URL.
 
-Additional entries can be customized by adding them to your project's config file (in '.trellis/cli.yml'):
+Additional entries can be customized by adding them to your project's config file (trellis.cli.yml):
 
   open:
     sentry: https://myapp.sentry.io

--- a/cmd/open_test.go
+++ b/cmd/open_test.go
@@ -74,7 +74,7 @@ func TestOpenRun(t *testing.T) {
 		{
 			"invalid_shortcut_name",
 			[]string{"invalid"},
-			"Error: shortcut 'invalid' does not exist.",
+			"Error: shortcut 'invalid' does not exist",
 			1,
 		},
 		{

--- a/main.go
+++ b/main.go
@@ -39,8 +39,7 @@ func main() {
 
 	trellis := trellis.NewTrellis()
 
-	// load global CLI config
-	if err := trellis.LoadCliConfig(); err != nil {
+	if err := trellis.LoadGlobalCliConfig(); err != nil {
 		ui.Error(err.Error())
 		os.Exit(1)
 	}

--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -291,8 +291,8 @@ func (t *Trellis) getDefaultSiteNameFromEnvironment(environment string) (siteNam
 	return sites[0], nil
 }
 
-func (t *Trellis) LoadCliConfig() error {
-	path := app_paths.ConfigPath(cliConfigFile)
+func (t *Trellis) LoadGlobalCliConfig() error {
+	path := app_paths.ConfigPath("cli.yml")
 
 	if err := t.CliConfig.LoadFile(path); err != nil {
 		return fmt.Errorf("Error loading CLI config %s\n\n%v", path, err)
@@ -306,10 +306,16 @@ func (t *Trellis) LoadCliConfig() error {
 }
 
 func (t *Trellis) LoadProjectCliConfig() error {
-	path := filepath.Join(t.ConfigPath(), cliConfigFile)
+	configPaths := []string{
+		filepath.Join(t.ConfigPath(), "cli.yml"),
+		filepath.Join(t.Path, "trellis.cli.yml"),
+		filepath.Join(t.Path, "trellis.cli.local.yml"),
+	}
 
-	if err := t.CliConfig.LoadFile(path); err != nil {
-		return fmt.Errorf("Error loading CLI config %s\n%v", path, err)
+	for _, path := range configPaths {
+		if err := t.CliConfig.LoadFile(path); err != nil {
+			return fmt.Errorf("Error loading CLI config %s\n%v", path, err)
+		}
 	}
 
 	t.CliConfig.LoadEnv("TRELLIS_")

--- a/trellis/trellis_test.go
+++ b/trellis/trellis_test.go
@@ -337,7 +337,7 @@ func TestLoadCliConfigWhenFileDoesNotExist(t *testing.T) {
 	t.Setenv("TRELLIS_CONFIG_DIR", tempDir)
 
 	tp := NewTrellis()
-	err := tp.LoadCliConfig()
+	err := tp.LoadGlobalCliConfig()
 
 	if err != nil {
 		t.Error("expected no error")
@@ -363,7 +363,7 @@ ask_vault_pass: true
 		t.Fatal(err)
 	}
 
-	err := tp.LoadCliConfig()
+	err := tp.LoadGlobalCliConfig()
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -391,7 +391,7 @@ ask_vault_pass: true
 		t.Fatal(err)
 	}
 
-	err := tp.LoadCliConfig()
+	err := tp.LoadGlobalCliConfig()
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
Adds more supported config files. In order of precedence, the following paths will be loaded:

* `.trellis/cli.yml` - existing file, now considered deprecated
* `trellis.cli.yml` - new path
* `trellis.cli.local.yml` - optional local override config

This change is being done to allow the `.trellis` directory to be gitigored as it contains CLI generated files that are machine specific and should not be committed to Git.