### PR TITLE
Improve consistency and usability of Vault commands

### DIFF
--- a/cmd/vault_decrypt_test.go
+++ b/cmd/vault_decrypt_test.go
@@ -69,6 +69,12 @@ func TestVaultDecryptRun(t *testing.T) {
 		code int
 	}{
 		{
+			"environment_with_files",
+			[]string{"-f=foo", "production"},
+			"Error: the file option can't be used together with the ENVIRONMENT argument",
+			1,
+		},
+		{
 			"default",
 			[]string{"production"},
 			"All files already decrypted",
@@ -76,19 +82,19 @@ func TestVaultDecryptRun(t *testing.T) {
 		},
 		{
 			"files_flag_single_file",
-			[]string{"--files=group_vars/production/vault.yml", "production"},
+			[]string{"-f=group_vars/production/vault.yml"},
 			"All files already decrypted",
 			0,
 		},
 		{
 			"files_flag_multiple_file",
-			[]string{"--files=group_vars/production/vault.yml,group_vars/development/vault.yml", "production"},
+			[]string{"-f=group_vars/production/vault.yml", "-f=group_vars/development/vault.yml"},
 			"All files already decrypted",
 			0,
 		},
 		{
 			"already_decrypted_file",
-			[]string{"--files=group_vars/production/encrypted.yml", "production"},
+			[]string{"-f=group_vars/production/encrypted.yml"},
 			"ansible-vault decrypt group_vars/production/encrypted.yml",
 			0,
 		},

--- a/cmd/vault_edit.go
+++ b/cmd/vault_edit.go
@@ -1,17 +1,37 @@
 package cmd
 
 import (
+	"flag"
 	"fmt"
+	"path/filepath"
 	"strings"
 
+	"github.com/manifoldco/promptui"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
 	"github.com/roots/trellis-cli/command"
+	"github.com/roots/trellis-cli/pkg/flags"
 	"github.com/roots/trellis-cli/trellis"
 )
 
 type VaultEditCommand struct {
 	UI      cli.Ui
 	Trellis *trellis.Trellis
+	flags   *flag.FlagSet
+	files   flags.StringSliceVar
+}
+
+func NewVaultEditCommand(ui cli.Ui, trellis *trellis.Trellis) *VaultEditCommand {
+	c := &VaultEditCommand{UI: ui, Trellis: trellis}
+	c.init()
+	return c
+}
+
+func (c *VaultEditCommand) init() {
+	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+	c.flags.Usage = func() { c.UI.Info(c.Help()) }
+	c.flags.Var(&c.files, "f", "File to edit. To edit multiple files, use this option multiple times.")
+	c.flags.Var(&c.files, "file", "File to edit. To edit multiple files, use this option multiple times.")
 }
 
 func (c *VaultEditCommand) Run(args []string) int {
@@ -22,7 +42,13 @@ func (c *VaultEditCommand) Run(args []string) int {
 
 	c.Trellis.CheckVirtualenv(c.UI)
 
-	commandArgumentValidator := &CommandArgumentValidator{required: 1, optional: 0}
+	if err := c.flags.Parse(args); err != nil {
+		return 1
+	}
+
+	args = c.flags.Args()
+
+	commandArgumentValidator := &CommandArgumentValidator{required: 0, optional: 0}
 	commandArgumentErr := commandArgumentValidator.validate(args)
 	if commandArgumentErr != nil {
 		c.UI.Error(commandArgumentErr.Error())
@@ -30,9 +56,33 @@ func (c *VaultEditCommand) Run(args []string) int {
 		return 1
 	}
 
-	file := args[0]
+	if c.files == nil {
+		matches, err := filepath.Glob("group_vars/*/vault.yml")
 
-	vaultEdit := command.WithOptions(command.WithTermOutput(), command.WithLogging(c.UI)).Cmd("ansible-vault", []string{"edit", file})
+		if err != nil {
+			c.UI.Error(err.Error())
+			return 1
+		}
+
+		prompt := promptui.Select{
+			Label: "Select a vault file to edit",
+			Items: matches,
+		}
+
+		_, file, err := prompt.Run()
+
+		if err != nil {
+			c.UI.Error("Aborting: no file selected")
+			return 1
+		}
+
+		c.files = []string{file}
+	}
+
+	vaultArgs := []string{"edit"}
+	vaultArgs = append(vaultArgs, c.files...)
+
+	vaultEdit := command.WithOptions(command.WithTermOutput(), command.WithLogging(c.UI)).Cmd("ansible-vault", vaultArgs)
 	err := vaultEdit.Run()
 
 	if err != nil {
@@ -49,7 +99,7 @@ func (c *VaultEditCommand) Synopsis() string {
 
 func (c *VaultEditCommand) Help() string {
 	helpText := `
-Usage: trellis vault edit [options] FILE
+Usage: trellis vault edit [options]
 
 Edit an encrypted file in place
 
@@ -58,14 +108,24 @@ Ansible Vault docs: https://docs.ansible.com/ansible/latest/user_guide/vault.htm
 
 Edit production file:
 
-  $ trellis vault edit group_vars/production/vault.yml
-
-Arguments:
-  FILE file name to edit
+  $ trellis vault edit -f group_vars/production/vault.yml
+  $ trellis vault edit -f group_vars/aaa/vault.yml -f group_vars/bbb/vault.yml
 
 Options:
-  -h, --help  show this help
+  -f, --file  File to edit. To edit multiple files, use this option multiple times.
+  -h, --help  Show this help
 `
 
 	return strings.TrimSpace(helpText)
+}
+
+func (c *VaultEditCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictNothing
+}
+
+func (c *VaultEditCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"-f":     complete.PredictFiles("*"),
+		"--file": complete.PredictFiles("*"),
+	}
 }

--- a/cmd/vault_edit_test.go
+++ b/cmd/vault_edit_test.go
@@ -26,7 +26,7 @@ func TestVaultEditRunValidations(t *testing.T) {
 		{
 			"too_many_args",
 			true,
-			[]string{"group_vars/all/vault.yml", "group_vars/production/vault.yml"},
+			[]string{"foo"},
 			"Error: too many arguments",
 			1,
 		},
@@ -36,7 +36,7 @@ func TestVaultEditRunValidations(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ui := cli.NewMockUi()
 			trellis := trellis.NewMockTrellis(tc.projectDetected)
-			vaultEditCommand := VaultEditCommand{ui, trellis}
+			vaultEditCommand := NewVaultEditCommand(ui, trellis)
 
 			code := vaultEditCommand.Run(tc.args)
 
@@ -66,7 +66,7 @@ func TestVaultEditRun(t *testing.T) {
 	}{
 		{
 			"default",
-			[]string{"group_vars/development/vault.yml"},
+			[]string{"-f", "group_vars/development/vault.yml"},
 			"ansible-vault edit group_vars/development/vault.yml",
 			0,
 		},
@@ -77,7 +77,7 @@ func TestVaultEditRun(t *testing.T) {
 			ui := cli.NewMockUi()
 			defer MockUiExec(t, ui)()
 
-			vaultEditCommand := VaultEditCommand{ui, trellis}
+			vaultEditCommand := NewVaultEditCommand(ui, trellis)
 			code := vaultEditCommand.Run(tc.args)
 
 			if code != tc.code {

--- a/cmd/vault_encrypt_test.go
+++ b/cmd/vault_encrypt_test.go
@@ -70,8 +70,8 @@ func TestVaultEncryptRun(t *testing.T) {
 	}{
 		{
 			"environment_with_files",
-			[]string{"--files=foo", "production"},
-			"Error: the files option can't be used together with the ENVIRONMENT argument",
+			[]string{"-f=foo", "production"},
+			"Error: the file option can't be used together with the ENVIRONMENT argument",
 			1,
 		},
 		{
@@ -88,19 +88,19 @@ func TestVaultEncryptRun(t *testing.T) {
 		},
 		{
 			"files_flag_single_file",
-			[]string{"--files=group_vars/production/vault.yml"},
+			[]string{"-f=group_vars/production/vault.yml"},
 			"ansible-vault encrypt group_vars/production/vault.yml",
 			0,
 		},
 		{
 			"files_flag_multiple_file",
-			[]string{"--files=group_vars/production/vault.yml,group_vars/development/vault.yml"},
+			[]string{"-f=group_vars/production/vault.yml", "-f=group_vars/development/vault.yml"},
 			"ansible-vault encrypt group_vars/production/vault.yml group_vars/development/vault.yml",
 			0,
 		},
 		{
 			"already_encrypted_file",
-			[]string{"--files=group_vars/production/encrypted.yml"},
+			[]string{"-f=group_vars/production/encrypted.yml"},
 			"All files already encrypted",
 			0,
 		},

--- a/cmd/vault_view_test.go
+++ b/cmd/vault_view_test.go
@@ -78,13 +78,13 @@ func TestVaultViewRun(t *testing.T) {
 		},
 		{
 			"files_flag_single_file",
-			[]string{"--files=foo", "production"},
+			[]string{"--file=foo"},
 			"ansible-vault view foo",
 			0,
 		},
 		{
 			"files_flag_multiple_file",
-			[]string{"--files=foo,bar", "production"},
+			[]string{"-f=foo", "-f=bar"},
 			"ansible-vault view foo bar",
 			0,
 		},

--- a/main.go
+++ b/main.go
@@ -153,7 +153,7 @@ func main() {
 			}, nil
 		},
 		"vault edit": func() (cli.Command, error) {
-			return &cmd.VaultEditCommand{UI: ui, Trellis: trellis}, nil
+			return cmd.NewVaultEditCommand(ui, trellis), nil
 		},
 		"vault encrypt": func() (cli.Command, error) {
 			return cmd.NewVaultEncryptCommand(ui, trellis), nil

--- a/pkg/flags/string_slice_var.go
+++ b/pkg/flags/string_slice_var.go
@@ -1,0 +1,12 @@
+package flags
+
+type StringSliceVar []string
+
+func (f *StringSliceVar) String() string {
+	return ""
+}
+
+func (f *StringSliceVar) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}


### PR DESCRIPTION
The `vault` commands weren't consistent and had weird quirks. This makes the commands consistent while providing better defaults and improved usability. Changes:

* `-f` (`--file`) replaces the existing `--files` flag is now supported on all 4 commands. The old `--files` was a comma separated string while the new `-f` can be used multiple times and will autocomplete files
* `-f` cannot be combined with a position `ENVIRONMENT` option on any command since it was confusing and inconsistent
* `vault view` and `vault edit` no longer require an argument. They will default to showing a select input UI to choose from a vault file.
<img width="375" alt="image" src="https://user-images.githubusercontent.com/295605/233819551-431e33f0-5e19-41f5-b526-902a4981f3c0.png">

* `vault encrypt` and `vault decrypt` no longer require an argument. Both will default to _all_ vault files.

Closes #356 