### PR TITLE
Fix use of reserved characters in wp-cli.yml

### DIFF
--- a/cmd/files/playbooks/alias_template.yml.j2
+++ b/cmd/files/playbooks/alias_template.yml.j2
@@ -1,9 +1,9 @@
 {% if include_local_env | default(false) %}
-'@{{ env }}':
+"@{{ env }}":
   ssh: "{{ local_hostname_alias }}"
   path: "{{ www_root + '/' + item.key | regex_replace('^~\/','') }}/{{ item.value.current_path | default('current') }}/{{ item.value.public_path | default('web') }}/wp"
 {% else %}
-'@{{ env }}':
+"@{{ env }}":
   ssh: "{{ web_user }}@{{ ansible_host }}:{{ ansible_port | default('22') }}"
   path: "{{ www_root + '/' + item.key | regex_replace('^~\/','') }}/{{ item.value.current_path | default('current') }}/{{ item.value.public_path | default('web') }}/wp"
 {% endif %}

--- a/cmd/files/playbooks/alias_template.yml.j2
+++ b/cmd/files/playbooks/alias_template.yml.j2
@@ -1,9 +1,9 @@
 {% if include_local_env | default(false) %}
-@{{ env }}:
+'@{{ env }}':
   ssh: "{{ local_hostname_alias }}"
   path: "{{ www_root + '/' + item.key | regex_replace('^~\/','') }}/{{ item.value.current_path | default('current') }}/{{ item.value.public_path | default('web') }}/wp"
 {% else %}
-@{{ env }}:
+'@{{ env }}':
   ssh: "{{ web_user }}@{{ ansible_host }}:{{ ansible_port | default('22') }}"
   path: "{{ www_root + '/' + item.key | regex_replace('^~\/','') }}/{{ item.value.current_path | default('current') }}/{{ item.value.public_path | default('web') }}/wp"
 {% endif %}

--- a/cmd/testdata/expected/alias/wp-cli.trellis-alias.yml
+++ b/cmd/testdata/expected/alias/wp-cli.trellis-alias.yml
@@ -1,9 +1,9 @@
-@development:
+"@development":
   ssh: "example.test"
   path: "/srv/www/example.com/current/web/wp"
-@production:
+"@production":
   ssh: "web@your_server_hostname:22"
   path: "/srv/www/example.com/current/web/wp"
-@staging:
+"@staging":
   ssh: "web@your_server_hostname:22"
   path: "/srv/www/example.com/current/web/wp"


### PR DESCRIPTION
I don't _think_ the generated `wp-cli.yml` is compliant with the yml spec.

> The “@” (x40, at) and “`” (x60, grave accent) are reserved for future use.

> Reserved indicators can't start a plain scalar.

— [yaml spec (1.2.2)](https://yaml.org/spec/1.2.2/)

`yamllint` and vscode's default YAML checks report errors, so I think I might be on to something.

```txt
test.yml
  1:1       error    syntax error: found character '@' that cannot start any token (syntax)
```