### PR TITLE
Refactor Lima config management

### DIFF
--- a/cmd/vm_start.go
+++ b/cmd/vm_start.go
@@ -73,9 +73,15 @@ func (c *VmStartCommand) Run(args []string) int {
 		return 1
 	}
 
-	// VM doesn't exist yet, create it
+	// VM doesn't exist yet, create and start it
 	if err = manager.CreateInstance(siteName); err != nil {
 		c.UI.Error("Error creating VM.")
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	if err = manager.StartInstance(siteName); err != nil {
+		c.UI.Error("Error starting VM.")
 		c.UI.Error(err.Error())
 		return 1
 	}


### PR DESCRIPTION
Fixes #421

Changes how the CLI generates and manages Lima VM configs to make changes like mounted directories be accurately reflected in Lima.

trellis-cli used to generate a config for Lima in
`.trellis/lima/{name}.yml` which was used for the initial creation of the VM. However, even when providing a config to `limactl create`, Lima creates a separate config in its managed directory (`$HOME/.lima/{name}/lima.yaml`).

This meant that any subsequent config changes in Trellis might only be persisted to the CLI's managed config (in `.trellis`), which would do nothing, instead of Lima's config.

For example, if you added a new site to Trellis (or changed the path to an existing one), you'd either have to delete the VM entirely and start over, or manually make the changes to Lima's config.

This PR removes the old CLI managed config entirely and instead updates Lima's config directly (the one in `$HOME/.lima`). This means one less file to manage and a single source of truth which will allow proper VM udpates.

Now if you change any wordpress sites in development, stopping and restarting the VM will apply the new config changes.