### PR TITLE
Fix CLI config file loading from directories outside of `trellis`

### DIFF
--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -21,8 +21,6 @@ const (
 	GlobPattern = "group_vars/*/wordpress_sites.yml"
 )
 
-const cliConfigFile = "cli.yml"
-
 type Options struct {
 	Detector  Detector
 	ConfigDir string
@@ -183,14 +181,14 @@ func (t *Trellis) LoadProject() error {
 		return errors.New("No Trellis project detected in the current directory or any of its parent directories.")
 	}
 
-	if err = t.LoadProjectCliConfig(); err != nil {
-		return err
-	}
-
 	t.Path = path
 	t.Virtualenv = NewVirtualenv(t.ConfigPath())
 
 	os.Chdir(t.Path)
+
+	if err = t.LoadProjectCliConfig(); err != nil {
+		return err
+	}
 
 	if t.CliConfig.VirtualenvIntegration {
 		if t.Virtualenv.Initialized() {


### PR DESCRIPTION
Fixes a bug where the project CLI config (`trellis.cli.yml`) was only loaded if the CLI command was run from within the `trellis` directory.

The project CLI config file was being loaded _before_ the project `Path` was set which meant it wasn't found and loaded. Now it's loaded after the `Path` is set.

cc @MWDelaney thanks!