### PR TITLE
Add GitHub attestation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      - uses: anchore/sbom-action/download-syft@v0
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,17 @@ on:
       - '*'
   workflow_dispatch:
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      build-provenance-artifact-id: ${{ steps.upload-build-provenance.outputs.artifact-id }}
+      sbom-artifact-id: ${{ steps.upload-sbom.outputs.artifact-id }}
+      sbom-attestations: ${{ steps.upload-sbom.outputs.attestations }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,11 +24,96 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      - uses: anchore/sbom-action/download-syft@v0
       - name: GoReleaser release
         uses: goreleaser/goreleaser-action@v6
         with:
-          distribution: goreleaser
-          version: latest
+          version: '~> v2'
           args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_ACCESS_TOKEN }}
+      - uses: actions/upload-artifact@v4
+        id: upload-build-provenance
+        with:
+          name: build-provenance
+          path: |
+            dist/trellis_*/trellis
+            dist/trellis_*/trellis.exe
+            dist/trellis_*.tar.gz
+            dist/trellis_*.zip
+            dist/**/*.sbom.json
+      - uses: typisttech/upload-goreleaser-sboms-action@v0
+        id: upload-sbom
+
+  attest-build-provenance:
+    needs: [goreleaser]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          name: build-provenance
+      - uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: |
+            dist/trellis_*/trellis
+            dist/trellis_*/trellis.exe
+            dist/trellis_*.tar.gz
+            dist/trellis_*.zip
+            dist/**/*.sbom.json
+      
+  attest-sbom:
+    needs: [goreleaser]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+    strategy:
+      matrix:
+        attestation: ${{ fromJSON(needs.goreleaser.outputs.sbom-attestations) }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: sboms
+      - uses: actions/attest-sbom@v1
+        with:
+          subject-path: ${{ matrix.attestation.subject }}
+          sbom-path: ${{ matrix.attestation.sbom }}
+
+  verify:
+    needs: [goreleaser, attest-build-provenance, attest-sbom]
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh release download --clobber --dir artifacts -p '*.tar.gz' -p '*.zip' -p '*.sbom.json' --repo $REPO $TAG
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+      - run: tree artifacts
+      - run: ls | xargs -I {} gh attestation verify --repo $REPO {}
+        working-directory: artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+
+  cleanup:
+    needs: [goreleaser, verify]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - run: >
+          gh api --method DELETE -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/$REPO/actions/artifacts/$ARTIFACT_ID
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ARTIFACT_ID: ${{ needs.goreleaser.outputs.build-provenance-artifact-id }}
+      - run: >
+          gh api --method DELETE -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/$REPO/actions/artifacts/$ARTIFACT_ID
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ARTIFACT_ID: ${{ needs.goreleaser.outputs.sbom-artifact-id }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,6 +29,8 @@ archives:
       format: zip
 checksum:
   name_template: '{{ .ProjectName }}_checksums.txt'
+sboms:
+  - artifacts: archive
 changelog:
   sort: asc
   filters:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,39 @@ setup after downloading the Windows build:
 4. Edit path from system variables and add new named `%TRELLIS%`
 5. Save the changes
 
+## Verify Attestation
+trellis-cli artifacts can be [cryptographically verified via GitHub CLI](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli).
+
+```console
+# The archive with both predicates
+$ gh attestation verify --repo roots/trellis-cli /path/to/trellis_Darwin_arm64.tar.gz
+## ...snipped...
+✓ Verification succeeded!
+
+sha256:xxx was attested by:
+REPO                   PREDICATE_TYPE                  WORKFLOW
+roots/trellis-cli  https://slsa.dev/provenance/v1  .github/workflows/release.yml@refs/tags/v9.8.7
+roots/trellis-cli  https://spdx.dev/Document/v2.3  .github/workflows/release.yml@refs/tags/v9.8.7
+
+# The binary
+$ gh attestation verify --repo roots/trellis-cli /path/to/trellis
+## ...snipped...
+✓ Verification succeeded!
+
+sha256:xxx was attested by:
+REPO                   PREDICATE_TYPE                  WORKFLOW
+roots/trellis-cli  https://slsa.dev/provenance/v1  .github/workflows/release.yml@refs/tags/v9.8.7
+
+# The SBOM
+$ gh attestation verify --repo roots/trellis-cli /path/to/trellis_Darwin_arm64.tar.gz.sbom.json
+## ...snipped...
+✓ Verification succeeded!
+
+sha256:xxx was attested by:
+REPO                   PREDICATE_TYPE                  WORKFLOW
+roots/trellis-cli  https://slsa.dev/provenance/v1  .github/workflows/release.yml@refs/tags/v9.8.7
+```
+
 ## Shell Integration
 
 ### Autocompletes


### PR DESCRIPTION
Example: https://github.com/tangrufus/trellis-cli/releases/tag/v1.12.2-alpha.9 which build with https://github.com/tangrufus/trellis-cli/blob/a8091f35faa0e2eaed38d28de7ba2d723e267f8c/.github/workflows/release.yml

```console
$ wget https://github.com/tangrufus/trellis-cli/releases/download/v1.12.2-alpha.9/trellis_Darwin_arm64.tar.gz.sbom.json
$ wget https://github.com/tangrufus/trellis-cli/releases/download/v1.12.2-alpha.9/trellis_Darwin_arm64.tar.gz
$ tar -zxvf trellis_Darwin_arm64.tar.gz

$ gh attestation verify --repo tangrufus/trellis-cli trellis_Darwin_arm64.tar.gz
Loaded digest sha256:60472939603d4ab8120f99d3106cc89cb48db8e59464b53c7ba7ab7e8601a153 for file://trellis_Darwin_arm64.tar.gz
Loaded 2 attestations from GitHub API
✓ Verification succeeded!

sha256:60472939603d4ab8120f99d3106cc89cb48db8e59464b53c7ba7ab7e8601a153 was attested by:
REPO                   PREDICATE_TYPE                  WORKFLOW
tangrufus/trellis-cli  https://slsa.dev/provenance/v1  .github/workflows/release.yml@refs/tags/v1.12.2-alpha.9
tangrufus/trellis-cli  https://spdx.dev/Document/v2.3  .github/workflows/release.yml@refs/tags/v1.12.2-alpha.9

$ gh attestation verify --repo tangrufus/trellis-cli trellis
Loaded digest sha256:98f9b387bb1e47a75a3bca010f97f0c71ad8653d1e94251810c6fb2a309788fe for file://trellis
Loaded 1 attestation from GitHub API
✓ Verification succeeded!

sha256:98f9b387bb1e47a75a3bca010f97f0c71ad8653d1e94251810c6fb2a309788fe was attested by:
REPO                   PREDICATE_TYPE                  WORKFLOW
tangrufus/trellis-cli  https://slsa.dev/provenance/v1  .github/workflows/release.yml@refs/tags/v1.12.2-alpha.9

$ gh attestation verify --repo tangrufus/trellis-cli trellis_Darwin_arm64.tar.gz.sbom.json
Loaded digest sha256:cd9ff82f98e3201afcb16d19fc7baa8c0427025d379ecc4c66e2042d293588be for file://trellis_Darwin_arm64.tar.gz.sbom.json
Loaded 1 attestation from GitHub API
✓ Verification succeeded!

sha256:cd9ff82f98e3201afcb16d19fc7baa8c0427025d379ecc4c66e2042d293588be was attested by:
REPO                   PREDICATE_TYPE                  WORKFLOW
tangrufus/trellis-cli  https://slsa.dev/provenance/v1  .github/workflows/release.yml@refs/tags/v1.12.2-alpha.9
```