### PR TITLE
Enable Lima's loadDotSSHPubKeys SSH option

### DIFF
--- a/pkg/lima/files/config.yml
+++ b/pkg/lima/files/config.yml
@@ -15,6 +15,7 @@ mounts:
 mountType: "virtiofs"
 ssh:
   forwardAgent: true
+  loadDotSSHPubKeys: true
 networks:
 - vzNAT: true
 {{ if .Config.PortForwards }}

--- a/pkg/lima/instance_test.go
+++ b/pkg/lima/instance_test.go
@@ -60,6 +60,7 @@ mounts:
 mountType: "virtiofs"
 ssh:
   forwardAgent: true
+  loadDotSSHPubKeys: true
 networks:
 - vzNAT: true
 
@@ -137,6 +138,7 @@ mounts:
 mountType: "virtiofs"
 ssh:
   forwardAgent: true
+  loadDotSSHPubKeys: true
 networks:
 - vzNAT: true
 


### PR DESCRIPTION
Lima v1.0.0 disabled this option by default but it's needed for Ansible which connects via SSH.