### PR TITLE
Fix install script

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -344,7 +344,7 @@ hash_sha256_verify() {
     return 1
   fi
   BASENAME=${TARGET##*/}
-  want=$(grep "${BASENAME}" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
+  want=$(grep -m1 "${BASENAME}$" "${checksums}" 2>/dev/null | tr '\t' ' ' | cut -d ' ' -f 1)
   if [ -z "$want" ]; then
     log_err "hash_sha256_verify unable to find checksum for '${TARGET}' in '${checksums}'"
     return 1


### PR DESCRIPTION
Fixes https://github.com/roots/trellis-cli/issues/490

The checksums file generated by goreleaser now includes the sbom.json attestion files which results in two lines like this:

```
88b16e7ae5acfcb21ffaa5ceec6f0c420d9b8574404fd9ad8fb444f60ce50afa  trellis_Darwin_arm64.tar.gz
1ff74331df023fc2b68e209fe12f16e8e9ca46ef498131a796f0d3939d38efc8  trellis_Darwin_arm64.tar.gz.sbom.json
```

This extra file with the same file prefix broke the checksum `grep` command since both lines were returned.

This updates the grep pattern to ensure the line ends in the expected archive name only. It also limits the results to 1 as a guarantee.