### PR TITLE
`vm` commands are now recommended over `up`/`down`

### DIFF
--- a/help.go
+++ b/help.go
@@ -9,26 +9,26 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-func experimentalCommandHelpFunc(app string, f cli.HelpFunc) cli.HelpFunc {
+func deprecatedCommandHelpFunc(commandNames []string, f cli.HelpFunc) cli.HelpFunc {
 	return func(commands map[string]cli.CommandFactory) string {
 		var buf bytes.Buffer
-		if len(experimentalCommands) > 0 {
-			buf.WriteString("\n\nExperimental commands:\n")
+		if len(commandNames) > 0 {
+			buf.WriteString("\n\nDeprecated commands:\n")
 		}
 
 		maxKeyLen := 0
-		keys := make([]string, 0, len(experimentalCommands))
+		keys := make([]string, 0, len(commandNames))
 		filteredCommands := make(map[string]cli.CommandFactory)
 
 		for key, command := range commands {
-			for _, experimentalKey := range experimentalCommands {
-				if key != experimentalKey {
+			for _, deprecatedKey := range commandNames {
+				if key != deprecatedKey {
 					filteredCommands[key] = command
 				}
 			}
 		}
 
-		for _, key := range experimentalCommands {
+		for _, key := range commandNames {
 			if len(key) > maxKeyLen {
 				maxKeyLen = len(key)
 			}

--- a/main.go
+++ b/main.go
@@ -19,8 +19,9 @@ import (
 // To be replaced by goreleaser build flags.
 var version = "canary"
 var updaterRepo = ""
-var experimentalCommands = []string{
-	"vm",
+var deprecatedCommands = []string{
+	"down",
+	"up",
 }
 
 func main() {
@@ -212,7 +213,7 @@ func main() {
 	}
 
 	c.HiddenCommands = []string{"venv", "venv hook"}
-	c.HelpFunc = experimentalCommandHelpFunc(c.Name, cli.BasicHelpFunc("trellis"))
+	c.HelpFunc = deprecatedCommandHelpFunc(deprecatedCommands, cli.BasicHelpFunc("trellis"))
 
 	if trellis.CliConfig.LoadPlugins {
 		pluginPaths := filepath.SplitList(os.Getenv("PATH"))


### PR DESCRIPTION
The `vm` commands are no longer marked as experimental and should be preferred over the Vagrant specific `up` and `down`, which are now marked as deprecated.

Note: Vagrant support in Trellis is _not_ deprecated, just these commands in the CLI. The `vm` commands use Lima so they aren't a direct replacement for Vagrant, but at this point Lima should be the default over Vagrant for macOS users at least since it offers a better experience. 