### PR TITLE
Update --inventory option

### DIFF
--- a/pkg/ansible/playbook.go
+++ b/pkg/ansible/playbook.go
@@ -34,7 +34,7 @@ func (p *Playbook) AddExtraVars(extraVars string) *Playbook {
 
 func (p *Playbook) SetInventory(path string) *Playbook {
 	if path != "" {
-		p.AddArg("--inventory-file", path)
+		p.AddArg("--inventory", path)
 	}
 
 	return p

--- a/pkg/ansible/playbook_test.go
+++ b/pkg/ansible/playbook_test.go
@@ -40,7 +40,7 @@ func TestPlaybookAll(t *testing.T) {
 
 	expected := []string{
 		"server.yml",
-		"--inventory-file=hosts/custom",
+		"--inventory=hosts/custom",
 		"--tags=users",
 		"-e env=production",
 		"-e site=example.com",


### PR DESCRIPTION
`--inventory-file` is deprecated and will be removed in Ansible 2.23