### PR TITLE
Forward Lima guest HTTP port to host

### DIFF
--- a/cli_config/cli_config.go
+++ b/cli_config/cli_config.go
@@ -17,11 +17,12 @@ type VmImage struct {
 }
 
 type VmConfig struct {
-	Manager       string    `yaml:"manager"`
-	HostsResolver string    `yaml:"hosts_resolver"`
-	Images        []VmImage `yaml:"images"`
-	Ubuntu        string    `yaml:"ubuntu"`
-	InstanceName  string    `yaml:"instance_name"`
+	Manager         string    `yaml:"manager"`
+	HostsResolver   string    `yaml:"hosts_resolver"`
+	Images          []VmImage `yaml:"images"`
+	Ubuntu          string    `yaml:"ubuntu"`
+	InstanceName    string    `yaml:"instance_name"`
+	ForwardHttpPort bool      `yaml:"forward_http_port"`
 }
 
 type Config struct {

--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -36,10 +36,11 @@ var DefaultCliConfig = cli_config.Config{
 	Open:                    make(map[string]string),
 	VirtualenvIntegration:   true,
 	Vm: cli_config.VmConfig{
-		Manager:       "auto",
-		HostsResolver: "hosts_file",
-		Ubuntu:        "24.04",
-		InstanceName:  "",
+		Manager:         "auto",
+		HostsResolver:   "hosts_file",
+		Ubuntu:          "24.04",
+		InstanceName:    "",
+		ForwardHttpPort: true,
 	},
 }
 


### PR DESCRIPTION
Related to https://github.com/roots/trellis-cli/issues/599

This isn't used yet but will give us more options in the future for different "host resolvers" instead of only relying on vzNAT's networking that makes the guest IP reachable on the host.

On Linux hosts for example, vzNAT isn't available so we would some sort of rever proxy implementation and that can only work with the guest HTTP port forwarded on the host.

There's a new CLI option to control this but it defaults to `true`.