### PR TITLE
Logs command: add VM support

### DIFF
--- a/cmd/alias.go
+++ b/cmd/alias.go
@@ -110,7 +110,7 @@ func (c *AliasCommand) Run(args []string) int {
 
 	defer c.aliasPlaybook.DumpFiles()()
 
-	devInventory := findDevInventory(c.Trellis, c.UI)
+	devInventory := c.Trellis.VmInventoryPath()
 
 	for _, environment := range envsToAlias {
 		playbook := ansible.Playbook{

--- a/cmd/db_open.go
+++ b/cmd/db_open.go
@@ -124,7 +124,7 @@ func (c *DBOpenCommand) Run(args []string) int {
 	}
 
 	if environment == "development" {
-		playbook.SetInventory(findDevInventory(c.Trellis, c.UI))
+		playbook.SetInventory(c.Trellis.VmInventoryPath())
 	}
 
 	mockUi := cli.NewMockUi()

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -98,7 +98,7 @@ func (c *DeployCommand) Run(args []string) int {
 			return 1
 		}
 
-		playbook.SetInventory(findDevInventory(c.Trellis, c.UI))
+		playbook.SetInventory(c.Trellis.VmInventoryPath())
 	}
 
 	if c.branch != "" {

--- a/cmd/dot_env.go
+++ b/cmd/dot_env.go
@@ -76,7 +76,7 @@ func (c *DotEnvCommand) Run(args []string) int {
 	}
 
 	if environment == "development" {
-		playbook.SetInventory(findDevInventory(c.Trellis, c.UI))
+		playbook.SetInventory(c.Trellis.VmInventoryPath())
 	}
 
 	mockUi := cli.NewMockUi()

--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -85,7 +85,7 @@ func (c *ProvisionCommand) Run(args []string) int {
 	if environment == "development" {
 		os.Setenv("ANSIBLE_HOST_KEY_CHECKING", "false")
 		playbook.SetName("dev.yml")
-		playbook.SetInventory(findDevInventory(c.Trellis, c.UI))
+		playbook.SetInventory(c.Trellis.VmInventoryPath())
 	}
 
 	provision := command.WithOptions(

--- a/pkg/vm/testing.go
+++ b/pkg/vm/testing.go
@@ -1,6 +1,8 @@
 package vm
 
 import (
+	"os/exec"
+
 	"github.com/hashicorp/cli"
 	"github.com/roots/trellis-cli/trellis"
 )
@@ -41,4 +43,12 @@ func (m *MockVmManager) StopInstance(name string) error {
 
 func (m *MockVmManager) OpenShell(name string, dir string, commandArgs []string) error {
 	return nil
+}
+
+func (m *MockVmManager) RunCommand(args []string, dir string) error {
+	return nil
+}
+
+func (m *MockVmManager) RunCommandPipe(args []string, dir string) (*exec.Cmd, error) {
+	return nil, nil
 }

--- a/pkg/vm/vm.go
+++ b/pkg/vm/vm.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"errors"
+	"os/exec"
 )
 
 var (
@@ -15,4 +16,6 @@ type Manager interface {
 	StartInstance(name string) error
 	StopInstance(name string) error
 	OpenShell(name string, dir string, commandArgs []string) error
+	RunCommand(args []string, dir string) error
+	RunCommandPipe(args []string, dir string) (*exec.Cmd, error)
 }

--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -381,4 +382,33 @@ func (t *Trellis) WriteYamlFile(s interface{}, path string, header string) error
 	}
 
 	return nil
+}
+
+func (t *Trellis) VmManagerType() string {
+	switch t.CliConfig.Vm.Manager {
+	case "auto":
+		if runtime.GOOS == "darwin" {
+			return "lima"
+		}
+		return ""
+	case "lima":
+		return "lima"
+	case "mock":
+		return "mock"
+	default:
+		return ""
+	}
+}
+
+func (t *Trellis) VmInventoryPath() string {
+	vmType := t.VmManagerType()
+	if vmType == "" {
+		return ""
+	}
+
+	inventoryPath := filepath.Join(t.ConfigPath(), vmType, "inventory")
+	if _, err := os.Stat(inventoryPath); err != nil {
+		return ""
+	}
+	return inventoryPath
 }


### PR DESCRIPTION
Closes #511

Automatic support for `trellis logs development` with dev virtual machines (Lima). Instead of hardcoding assumptions of ssh, this detects VM usage and uses the `vm.Manager` interface to run commands directly on the VM. In Lima's case, it uses `limactl shell` under the hood.