### PR TITLE
Add --skip-tags support to `provision`

### DIFF
--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -23,6 +23,7 @@ type ProvisionCommand struct {
 	flags     *flag.FlagSet
 	extraVars string
 	tags      string
+	skipTags  string
 	Trellis   *trellis.Trellis
 	verbose   bool
 }
@@ -32,6 +33,7 @@ func (c *ProvisionCommand) init() {
 	c.flags.Usage = func() { c.UI.Info(c.Help()) }
 	c.flags.StringVar(&c.extraVars, "extra-vars", "", "Additional variables which are passed through to Ansible as 'extra-vars'")
 	c.flags.StringVar(&c.tags, "tags", "", "only run roles and tasks tagged with these values")
+	c.flags.StringVar(&c.skipTags, "skip-tags", "", "skip roles and tasks tagged with these values")
 	c.flags.BoolVar(&c.verbose, "verbose", false, "Enable Ansible's verbose mode")
 }
 
@@ -80,6 +82,10 @@ func (c *ProvisionCommand) Run(args []string) int {
 
 	if c.tags != "" {
 		playbook.AddArg("--tags", c.tags)
+	}
+
+	if c.skipTags != "" {
+		playbook.AddArg("--skip-tags", c.skipTags)
 	}
 
 	if environment == "development" {
@@ -135,6 +141,7 @@ Arguments:
   
 Options:
       --extra-vars  (multiple) Set additional variables as key=value or YAML/JSON, if filename prepend with @
+      --skip-tags   (multiple) Skip roles and tasks tagged with these values
       --tags        (multiple) Only run roles and tasks tagged with these values
       --verbose     Enable Ansible's verbose mode
   -h, --help        Show this help
@@ -150,6 +157,7 @@ func (c *ProvisionCommand) AutocompleteArgs() complete.Predictor {
 func (c *ProvisionCommand) AutocompleteFlags() complete.Flags {
 	return complete.Flags{
 		"--extra-vars": complete.PredictNothing,
+		"--skip-tags":  complete.PredictNothing,
 		"--tags":       complete.PredictNothing,
 		"--verbose":    complete.PredictNothing,
 	}

--- a/cmd/provision_test.go
+++ b/cmd/provision_test.go
@@ -99,6 +99,18 @@ func TestProvisionRun(t *testing.T) {
 			0,
 		},
 		{
+			"with_skip_tags",
+			[]string{"-skip-tags", "users", "development"},
+			"ansible-playbook dev.yml --skip-tags=users -e env=development",
+			0,
+		},
+		{
+			"with_tags_and_skip_tags",
+			[]string{"-tags", "deploy", "-skip-tags", "users", "development"},
+			"ansible-playbook dev.yml --tags=deploy --skip-tags=users -e env=development",
+			0,
+		},
+		{
 			"with_extra_vars",
 			[]string{"-extra-vars", "k=v foo=bar", "development"},
 			"ansible-playbook dev.yml -e k=v foo=bar -e env=development",


### PR DESCRIPTION
Closes https://github.com/roots/trellis-cli/issues/589

Works the same as `tags` but for skipping tags.