### PR TITLE
Add `server` commands with extensible provider support

### DIFF
--- a/cli_config/cli_config.go
+++ b/cli_config/cli_config.go
@@ -25,6 +25,10 @@ type VmConfig struct {
 	ForwardHttpPort bool      `yaml:"forward_http_port"`
 }
 
+type ServerConfig struct {
+	Provider string `yaml:"provider"`
+}
+
 type Config struct {
 	AllowDevelopmentDeploys bool              `yaml:"allow_development_deploys"`
 	AskVaultPass            bool              `yaml:"ask_vault_pass"`
@@ -34,6 +38,7 @@ type Config struct {
 	Open                    map[string]string `yaml:"open"`
 	VirtualenvIntegration   bool              `yaml:"virtualenv_integration"`
 	Vm                      VmConfig          `yaml:"vm"`
+	Server                  ServerConfig      `yaml:"server"`
 }
 
 var (
@@ -71,6 +76,10 @@ func (c *Config) LoadFile(path string) error {
 
 	if c.DatabaseApp != "" && c.DatabaseApp != "tableplus" && c.DatabaseApp != "sequel-ace" {
 		return fmt.Errorf("%w: unsupported value for `database_app`. Must be one of: tableplus, sequel-ace", InvalidConfigErr)
+	}
+
+	if c.Server.Provider != "" && c.Server.Provider != "digitalocean" {
+		return fmt.Errorf("%w: unsupported value for `server.provider`. Must be one of: digitalocean", InvalidConfigErr)
 	}
 
 	return nil

--- a/cmd/droplet_create.go
+++ b/cmd/droplet_create.go
@@ -50,6 +50,9 @@ func (c *DropletCreateCommand) init() {
 }
 
 func (c *DropletCreateCommand) Run(args []string) int {
+	c.UI.Warn("DEPRECATED: 'trellis droplet create' is deprecated. Use 'trellis server create' instead.")
+	c.UI.Warn("This command will be removed in a future version.\n")
+
 	if err := c.Trellis.LoadProject(); err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/cmd/droplet_dns.go
+++ b/cmd/droplet_dns.go
@@ -38,6 +38,9 @@ func (c *DropletDnsCommand) init() {
 }
 
 func (c *DropletDnsCommand) Run(args []string) int {
+	c.UI.Warn("DEPRECATED: 'trellis droplet dns' is deprecated. Use 'trellis server dns' instead.")
+	c.UI.Warn("This command will be removed in a future version.\n")
+
 	if err := c.Trellis.LoadProject(); err != nil {
 		c.UI.Error(err.Error())
 		return 1

--- a/cmd/server_create.go
+++ b/cmd/server_create.go
@@ -1,0 +1,421 @@
+package cmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/user"
+	"strings"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/hashicorp/cli"
+	"github.com/manifoldco/promptui"
+	"github.com/posener/complete"
+	"github.com/roots/trellis-cli/pkg/server"
+	"github.com/roots/trellis-cli/trellis"
+)
+
+func NewServerCreateCommand(ui cli.Ui, trellis *trellis.Trellis) *ServerCreateCommand {
+	c := &ServerCreateCommand{UI: ui, Trellis: trellis}
+	c.init()
+	return c
+}
+
+type ServerCreateCommand struct {
+	UI            cli.Ui
+	Trellis       *trellis.Trellis
+	flags         *flag.FlagSet
+	providerFlag  string
+	sshKey        string
+	region        string
+	image         string
+	size          string
+	skipProvision bool
+}
+
+func (c *ServerCreateCommand) init() {
+	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+	c.flags.Usage = func() { c.UI.Info(c.Help()) }
+	c.flags.StringVar(&c.providerFlag, "provider", "", "Cloud provider (digitalocean)")
+	c.flags.StringVar(&c.sshKey, "ssh-key", "", "Path to SSH public key to automatically add to new server")
+	c.flags.StringVar(&c.region, "region", "", "Region to create the server in")
+	c.flags.StringVar(&c.image, "image", "", "Server image (default: Ubuntu 24.04)")
+	c.flags.StringVar(&c.size, "size", "", "Server size/type to create")
+	c.flags.BoolVar(&c.skipProvision, "skip-provision", false, "Create the server but skip provisioning")
+}
+
+func (c *ServerCreateCommand) Run(args []string) int {
+	if err := c.Trellis.LoadProject(); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	c.Trellis.CheckVirtualenv(c.UI)
+
+	if err := c.flags.Parse(args); err != nil {
+		return 1
+	}
+
+	args = c.flags.Args()
+
+	commandArgumentValidator := &CommandArgumentValidator{required: 1, optional: 0}
+	commandArgumentErr := commandArgumentValidator.validate(args)
+	if commandArgumentErr != nil {
+		c.UI.Error(commandArgumentErr.Error())
+		c.UI.Output(c.Help())
+		return 1
+	}
+
+	environment := args[0]
+
+	environmentErr := c.Trellis.ValidateEnvironment(environment)
+	if environmentErr != nil {
+		c.UI.Error(environmentErr.Error())
+		return 1
+	}
+
+	if environment == "development" {
+		c.UI.Error("server create command only supports staging/production environments")
+		return 1
+	}
+
+	providerName := c.resolveProvider()
+
+	token, err := server.GetProviderToken(providerName, c.UI)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error: %s API token is required.", providerName))
+		return 1
+	}
+
+	provider, err := server.NewProvider(providerName, token)
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	c.UI.Info(fmt.Sprintf("Using %s provider\n", provider.DisplayName()))
+
+	// SSH key handling
+	sshKeyPaths := server.DefaultSSHKeyPaths
+	if c.sshKey != "" {
+		sshKeyPaths = []string{c.sshKey}
+	}
+
+	sshKeyPath, contents, publicKey, err := server.LoadSSHKey(sshKeyPaths)
+	if err != nil {
+		c.UI.Error("Error: can't continue without an SSH key")
+		c.UI.Error(err.Error())
+		c.UI.Error("\nThe --ssh-key option can be used to specify the path of a valid SSH key.")
+		return 1
+	}
+
+	ctx := context.Background()
+	fingerprint := server.SSHKeyFingerprint(publicKey)
+
+	existingKey, err := provider.GetSSHKey(ctx, fingerprint)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error checking SSH key: %s", err))
+		return 1
+	}
+
+	if existingKey == nil {
+		c.UI.Info(fmt.Sprintf("SSH Key [%s] does not exist in %s.", sshKeyPath, provider.DisplayName()))
+
+		prompt := promptui.Prompt{
+			Label:     "Add SSH key to account",
+			IsConfirm: true,
+		}
+
+		_, err := prompt.Run()
+		if err != nil {
+			c.UI.Error("Can't continue without an SSH key on your account.")
+			return 1
+		}
+
+		keyName := "trellis-cli-ssh-key"
+		if u, err := user.Current(); err == nil {
+			keyName = u.Username
+		}
+
+		_, err = provider.CreateSSHKey(ctx, keyName, string(contents))
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Error creating SSH key: %s", err))
+			return 1
+		}
+	}
+
+	c.UI.Info(fmt.Sprintf("Using SSH key at %s\n", sshKeyPath))
+
+	// Region selection
+	if c.region == "" {
+		regions, err := provider.GetRegions(ctx)
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Error fetching regions: %s", err))
+			return 1
+		}
+
+		c.region, err = c.selectRegion(regions)
+		if err != nil {
+			c.UI.Error(err.Error())
+			return 1
+		}
+	}
+
+	// Size selection
+	if c.size == "" {
+		sizes, err := provider.GetSizes(ctx, c.region)
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Error fetching sizes: %s", err))
+			return 1
+		}
+
+		c.size, err = c.selectSize(sizes)
+		if err != nil {
+			c.UI.Error(err.Error())
+			return 1
+		}
+	}
+
+	// Image default
+	if c.image == "" {
+		c.image = server.DefaultImage(providerName)
+	}
+
+	// Server name
+	siteNames := c.Trellis.SiteNamesFromEnvironment(environment)
+	name, err := c.askServerName(siteNames[0])
+	if err != nil {
+		return 1
+	}
+
+	// Create server
+	srv, err := c.createServer(ctx, provider, name, environment, fingerprint)
+	if err != nil {
+		return 1
+	}
+
+	// Wait for server to be ready
+	srv, err = c.waitForServer(ctx, provider, srv)
+	if err != nil {
+		return 1
+	}
+
+	// Update hosts file
+	_, err = c.Trellis.UpdateHosts(environment, srv.PublicIPv4)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error updating Trellis hosts file: %s", err))
+		return 1
+	}
+
+	c.UI.Info(fmt.Sprintf("%s Updated hosts/%s with server IP: %s", color.GreenString("[✓]"), environment, srv.PublicIPv4))
+
+	if c.skipProvision {
+		c.UI.Warn(fmt.Sprintf("Skipping provision. Run `trellis provision %s` to manually provision.", environment))
+	} else {
+		c.UI.Info("\nProvisioning server...\n")
+
+		provisionCmd := NewProvisionCommand(c.UI, c.Trellis)
+		return provisionCmd.Run([]string{environment})
+	}
+
+	return 0
+}
+
+func (c *ServerCreateCommand) resolveProvider() server.ProviderName {
+	if c.providerFlag != "" {
+		return server.ProviderName(c.providerFlag)
+	}
+	if env := os.Getenv("TRELLIS_SERVER_PROVIDER"); env != "" {
+		return server.ProviderName(env)
+	}
+	if c.Trellis.CliConfig.Server.Provider != "" {
+		return server.ProviderName(c.Trellis.CliConfig.Server.Provider)
+	}
+	return server.ProviderDigitalOcean
+}
+
+func (c *ServerCreateCommand) Synopsis() string {
+	return "Creates a cloud server and provisions it"
+}
+
+func (c *ServerCreateCommand) Help() string {
+	helpText := `
+Usage: trellis server create [options] ENVIRONMENT
+
+Creates a server on a cloud provider for the environment specified.
+
+Only remote servers (for staging and production) are currently supported.
+Development should be managed separately through the VM commands.
+
+Supported providers:
+  - digitalocean (default)
+
+The provider can be configured via:
+  1. --provider flag
+  2. TRELLIS_SERVER_PROVIDER environment variable
+  3. server.provider in trellis.cli.yml
+
+Create a production server (region and size will be prompted):
+
+  $ trellis server create production
+
+Create a server in a specific region:
+
+  $ trellis server create --region=nyc3 --size=s-1vcpu-1gb production
+
+Create a server but skip provisioning:
+
+  $ trellis server create --skip-provision production
+
+Arguments:
+  ENVIRONMENT Name of environment (ie: production)
+
+Options:
+      --provider        Cloud provider (digitalocean)
+      --region          Region to create the server in
+      --image           Server image (default: Ubuntu 24.04)
+      --size            Server size/type
+      --skip-provision  Skip provision after server is created
+      --ssh-key         Path to SSH public key to be added on the server
+  -h, --help            show this help
+`
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *ServerCreateCommand) AutocompleteArgs() complete.Predictor {
+	return c.Trellis.PredictEnvironment(c.flags)
+}
+
+func (c *ServerCreateCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"--provider":        complete.PredictSet("digitalocean"),
+		"--region":          complete.PredictNothing,
+		"--size":            complete.PredictNothing,
+		"--skip--provision": complete.PredictNothing,
+		"--ssh-key":         complete.PredictFiles("*.pub"),
+	}
+}
+
+func (c *ServerCreateCommand) askServerName(siteName string) (string, error) {
+	name, err := c.UI.Ask(fmt.Sprintf("Server name [%s]:", color.GreenString(siteName)))
+	if err != nil {
+		return "", err
+	}
+
+	if name == "" {
+		name = siteName
+	}
+
+	return name, nil
+}
+
+func (c *ServerCreateCommand) selectRegion(regions []server.Region) (string, error) {
+	tpl := `{{ .Name }} [{{ .Slug | faint}}]`
+
+	templates := &promptui.SelectTemplates{
+		Active:   fmt.Sprintf("%s %s", promptui.IconSelect, tpl),
+		Inactive: tpl,
+		Selected: fmt.Sprintf(`{{ "%s" | green }} %s`, promptui.IconGood, tpl),
+	}
+
+	prompt := promptui.Select{
+		Label:     "Select Region",
+		Templates: templates,
+		Items:     regions,
+		Size:      len(regions),
+	}
+
+	i, _, err := prompt.Run()
+	if err != nil {
+		return "", err
+	}
+
+	return regions[i].Slug, nil
+}
+
+func (c *ServerCreateCommand) selectSize(sizes []server.Size) (string, error) {
+	tpl := `${{ printf "%.2f" .PriceMonthly }}/mo - {{ .Slug | faint }} [{{ .Memory }}MB | {{ .VCPUs }} CPUs | {{ .Disk }}GB SSD]`
+
+	templates := &promptui.SelectTemplates{
+		Active:   fmt.Sprintf("%s %s", promptui.IconSelect, tpl),
+		Inactive: tpl,
+		Selected: fmt.Sprintf(`{{ "%s" | green }} %s`, promptui.IconGood, tpl),
+	}
+
+	prompt := promptui.Select{
+		Label:     "Select Size",
+		Items:     sizes,
+		Templates: templates,
+		Size:      len(sizes),
+	}
+
+	i, _, err := prompt.Run()
+	if err != nil {
+		return "", err
+	}
+
+	return sizes[i].Slug, nil
+}
+
+func (c *ServerCreateCommand) createServer(ctx context.Context, provider server.Provider, name, env, sshFingerprint string) (*server.Server, error) {
+	srv, err := provider.CreateServer(ctx, server.CreateServerOptions{
+		Name:      name,
+		Region:    c.region,
+		Size:      c.size,
+		Image:     c.image,
+		SSHKeyIDs: []string{sshFingerprint},
+		Tags:      map[string]string{"env": env},
+	})
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error creating server: %s", err))
+		return nil, err
+	}
+
+	c.UI.Info(fmt.Sprintf("\n%s Server created => %s", color.GreenString("[✓]"), srv.DashboardURL))
+
+	return srv, nil
+}
+
+func (c *ServerCreateCommand) waitForServer(ctx context.Context, provider server.Provider, srv *server.Server) (*server.Server, error) {
+	s := NewSpinner(
+		SpinnerCfg{
+			Message:     "Waiting for server to boot (this may take a minute)",
+			StopMessage: "Server booted",
+			FailMessage: "Server did not become active (or timed out)",
+		},
+	)
+
+	_ = s.Start()
+	srv, err := provider.WaitForServer(ctx, srv.ID, 5*time.Minute)
+	if err != nil {
+		_ = s.StopFail()
+		c.UI.Error(err.Error())
+		return nil, err
+	}
+	_ = s.Stop()
+
+	// Wait for SSH
+	s = NewSpinner(
+		SpinnerCfg{
+			Message:     "Waiting for SSH (this may take a minute)",
+			StopMessage: "SSH available",
+			FailMessage: "Timeout waiting for SSH",
+		},
+	)
+
+	sshCtx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	defer cancel()
+
+	_ = s.Start()
+	err = server.WaitForSSH(sshCtx, srv.PublicIPv4)
+	if err != nil {
+		_ = s.StopFail()
+		return nil, err
+	}
+	_ = s.Stop()
+
+	return srv, nil
+}

--- a/cmd/server_dns.go
+++ b/cmd/server_dns.go
@@ -1,0 +1,294 @@
+package cmd
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/fatih/color"
+	"github.com/hashicorp/cli"
+	"github.com/manifoldco/promptui"
+	"github.com/posener/complete"
+	"github.com/roots/trellis-cli/pkg/server"
+	"github.com/roots/trellis-cli/trellis"
+)
+
+func NewServerDnsCommand(ui cli.Ui, trellis *trellis.Trellis) *ServerDnsCommand {
+	c := &ServerDnsCommand{UI: ui, Trellis: trellis}
+	c.init()
+	return c
+}
+
+type ServerDnsCommand struct {
+	UI           cli.Ui
+	Trellis      *trellis.Trellis
+	flags        *flag.FlagSet
+	providerFlag string
+	force        bool
+	ip           string
+}
+
+func (c *ServerDnsCommand) init() {
+	c.flags = flag.NewFlagSet("", flag.ContinueOnError)
+	c.flags.Usage = func() { c.UI.Info(c.Help()) }
+	c.flags.StringVar(&c.providerFlag, "provider", "", "Cloud provider (digitalocean)")
+	c.flags.BoolVar(&c.force, "force", false, "Force update of DNS records even if they exist")
+	c.flags.StringVar(&c.ip, "ip", "", "Host IP of DNS records")
+}
+
+func (c *ServerDnsCommand) Run(args []string) int {
+	if err := c.Trellis.LoadProject(); err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	c.Trellis.CheckVirtualenv(c.UI)
+
+	if err := c.flags.Parse(args); err != nil {
+		return 1
+	}
+
+	args = c.flags.Args()
+
+	commandArgumentValidator := &CommandArgumentValidator{required: 1, optional: 0}
+	commandArgumentErr := commandArgumentValidator.validate(args)
+	if commandArgumentErr != nil {
+		c.UI.Error(commandArgumentErr.Error())
+		c.UI.Output(c.Help())
+		return 1
+	}
+
+	environment := args[0]
+
+	environmentErr := c.Trellis.ValidateEnvironment(environment)
+	if environmentErr != nil {
+		c.UI.Error(environmentErr.Error())
+		return 1
+	}
+
+	if environment == "development" {
+		c.UI.Error("dns command only supports non-development environments")
+		return 1
+	}
+
+	providerName := c.resolveProvider()
+
+	token, err := server.GetProviderToken(providerName, c.UI)
+	if err != nil {
+		c.UI.Error(fmt.Sprintf("Error: %s API token is required.", providerName))
+		return 1
+	}
+
+	provider, err := server.NewProviderWithDNS(providerName, token)
+	if err != nil {
+		c.UI.Error(err.Error())
+		return 1
+	}
+
+	ctx := context.Background()
+
+	if c.ip == "" {
+		c.ip, err = c.selectIP(ctx, provider)
+		c.UI.Info("")
+
+		if err != nil {
+			c.UI.Error("Error: can't continue without a host IP.")
+			return 1
+		}
+	}
+
+	c.UI.Info(fmt.Sprintf("DNS records for the following domains will be pointed to %s", c.ip))
+
+	hostsByDomain := c.Trellis.Environments[environment].AllHostsByDomain()
+	for _, hosts := range hostsByDomain {
+		for _, host := range hosts {
+			c.UI.Info("  " + host.Fqdn)
+		}
+	}
+
+	c.UI.Info("")
+
+	prompt := promptui.Prompt{Label: "Create DNS records", IsConfirm: true}
+	if _, err = prompt.Run(); err != nil {
+		return 0
+	}
+
+	for domain, hosts := range hostsByDomain {
+		// Check if zone exists, create if not
+		_, exists, err := provider.GetZone(ctx, domain)
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Error checking domain %s: %v", domain, err))
+			return 1
+		}
+
+		if !exists {
+			if err := provider.CreateZone(ctx, domain); err != nil {
+				c.UI.Error(fmt.Sprintf("Error: could not create domain %s\n%v", domain, err))
+				return 1
+			}
+		}
+
+		// Get existing records
+		existingRecords, err := provider.ListRecords(ctx, domain)
+		if err != nil {
+			c.UI.Error(fmt.Sprintf("Error listing records for %s: %v", domain, err))
+			return 1
+		}
+
+		for _, host := range hosts {
+			// Check if record exists
+			var existingRecord *server.DNSRecord
+			for _, r := range existingRecords {
+				if r.Type == "A" && r.Name == host.Name {
+					existingRecord = &r
+					break
+				}
+			}
+
+			if existingRecord != nil {
+				if c.force {
+					err := provider.DeleteRecord(ctx, domain, existingRecord.ID)
+					if err != nil {
+						c.UI.Error(fmt.Sprintf("Error: could not delete existing record %s\n%v", host.Fqdn, err))
+						continue
+					}
+				} else {
+					c.UI.Info(fmt.Sprintf("%s %s", color.YellowString("[SKIPPED]"), host.Fqdn))
+					continue
+				}
+			}
+
+			_, err := provider.CreateRecord(ctx, domain, server.DNSRecord{
+				Type:  "A",
+				Name:  host.Name,
+				Value: c.ip,
+			})
+
+			if err == nil {
+				c.UI.Info(fmt.Sprintf("%s %s", color.GreenString("[CREATED]"), host.Fqdn))
+			} else {
+				c.UI.Info(fmt.Sprintf("%s %s", color.RedString("[ERROR]"), host.Fqdn))
+				c.UI.Error(err.Error())
+			}
+		}
+	}
+
+	return 0
+}
+
+func (c *ServerDnsCommand) resolveProvider() server.ProviderName {
+	if c.providerFlag != "" {
+		return server.ProviderName(c.providerFlag)
+	}
+	if env := os.Getenv("TRELLIS_SERVER_PROVIDER"); env != "" {
+		return server.ProviderName(env)
+	}
+	if c.Trellis.CliConfig.Server.Provider != "" {
+		return server.ProviderName(c.Trellis.CliConfig.Server.Provider)
+	}
+	return server.ProviderDigitalOcean
+}
+
+func (c *ServerDnsCommand) Synopsis() string {
+	return "Creates DNS records for all WordPress sites' hosts in an environment"
+}
+
+func (c *ServerDnsCommand) Help() string {
+	helpText := `
+Usage: trellis server dns [options] ENVIRONMENT
+
+Creates DNS records for all WordPress sites' hosts in an environment.
+DNS records (type A) will be created for each host that all point to the
+server IP; the host IP can be manually overridden if need be.
+
+Supported providers:
+  - digitalocean (default)
+
+The provider can be configured via:
+  1. --provider flag
+  2. TRELLIS_SERVER_PROVIDER environment variable
+  3. server.provider in trellis.cli.yml
+
+Note: this command assumes your domain's DNS is managed by the cloud provider
+and the nameservers have already been set appropriately.
+
+This command only supports Trellis' standard setup of one server per environment.
+If your sites are split across multiple servers, then this command won't work and
+you should manage your DNS manually.
+
+Create DNS records for the production server:
+
+  $ trellis server dns production
+
+Force re-creation of existing DNS records:
+
+  $ trellis server dns --force production
+
+Manually specify the host IP to use:
+
+  $ trellis server dns --ip 1.2.3.4 production
+
+Arguments:
+  ENVIRONMENT Name of environment (ie: production)
+
+Options:
+      --provider  Cloud provider (digitalocean)
+      --force     Force updating DNS records even if they already exist
+      --ip        Host IP of DNS records
+  -h, --help      Show this help
+`
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *ServerDnsCommand) AutocompleteArgs() complete.Predictor {
+	return c.Trellis.PredictEnvironment(c.flags)
+}
+
+func (c *ServerDnsCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{
+		"--provider": complete.PredictSet("digitalocean"),
+		"--ip":       complete.PredictNothing,
+		"--force":    complete.PredictNothing,
+	}
+}
+
+func (c *ServerDnsCommand) selectIP(ctx context.Context, provider server.Provider) (string, error) {
+	servers, err := provider.GetServers(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	if len(servers) == 0 {
+		return "", fmt.Errorf("no servers found")
+	}
+
+	tpl := `{{.Name}} [{{.PublicIPv4 | faint}}]`
+
+	templates := &promptui.SelectTemplates{
+		Active:   fmt.Sprintf("%s %s", promptui.IconSelect, tpl),
+		Inactive: tpl,
+		Selected: fmt.Sprintf(`{{ "%s" | green }} %s`, promptui.IconGood, tpl),
+		FuncMap: template.FuncMap{
+			"green": promptui.Styler(promptui.FGGreen),
+			"faint": promptui.Styler(promptui.FGFaint),
+		},
+	}
+
+	prompt := promptui.Select{
+		Label:     "Select Server IP",
+		Templates: templates,
+		Items:     servers,
+		Size:      len(servers),
+	}
+
+	i, _, err := prompt.Run()
+	if err != nil {
+		return "", err
+	}
+
+	return servers[i].PublicIPv4, nil
+}

--- a/help.go
+++ b/help.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/cli"
+)
+
+func deprecatedCommandHelpFunc(commandNames []string, f cli.HelpFunc) cli.HelpFunc {
+	return func(commands map[string]cli.CommandFactory) string {
+		var buf bytes.Buffer
+		if len(commandNames) > 0 {
+			buf.WriteString("\n\nDeprecated commands:\n")
+		}
+
+		maxKeyLen := 0
+		keys := make([]string, 0, len(commandNames))
+		filteredCommands := make(map[string]cli.CommandFactory)
+
+		for key, command := range commands {
+			for _, deprecatedKey := range commandNames {
+				if key != deprecatedKey {
+					filteredCommands[key] = command
+				}
+			}
+		}
+
+		for _, key := range commandNames {
+			if len(key) > maxKeyLen {
+				maxKeyLen = len(key)
+			}
+
+			keys = append(keys, key)
+		}
+
+		sort.Strings(keys)
+
+		for _, key := range keys {
+			commandFunc := commands[key]
+			command, _ := commandFunc()
+			key = fmt.Sprintf("%s%s", key, strings.Repeat(" ", maxKeyLen-len(key)))
+			buf.WriteString(fmt.Sprintf("    %s    %s\n", key, command.Synopsis()))
+		}
+
+		return f(filteredCommands) + buf.String()
+	}
+}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,9 @@ import (
 // To be replaced by goreleaser build flags.
 var version = "canary"
 var updaterRepo = ""
+var deprecatedCommands = []string{
+	"droplet",
+}
 
 func main() {
 	c := cli.NewCLI("trellis", version)
@@ -80,7 +83,7 @@ func main() {
 		"droplet": func() (cli.Command, error) {
 			return &cmd.NamespaceCommand{
 				HelpText:     "Usage: trellis droplet <subcommand> [<args>]",
-				SynopsisText: "Commands for DigitalOcean Droplets",
+				SynopsisText: "Commands for DigitalOcean Droplets (deprecated: use 'server' instead)",
 			}, nil
 		},
 		"droplet create": func() (cli.Command, error) {
@@ -88,6 +91,18 @@ func main() {
 		},
 		"droplet dns": func() (cli.Command, error) {
 			return cmd.NewDropletDnsCommand(ui, trellis), nil
+		},
+		"server": func() (cli.Command, error) {
+			return &cmd.NamespaceCommand{
+				HelpText:     "Usage: trellis server <subcommand> [<args>]",
+				SynopsisText: "Commands for cloud server management",
+			}, nil
+		},
+		"server create": func() (cli.Command, error) {
+			return cmd.NewServerCreateCommand(ui, trellis), nil
+		},
+		"server dns": func() (cli.Command, error) {
+			return cmd.NewServerDnsCommand(ui, trellis), nil
 		},
 		"exec": func() (cli.Command, error) {
 			return &cmd.ExecCommand{UI: ui, Trellis: trellis}, nil
@@ -203,7 +218,7 @@ func main() {
 	}
 
 	c.HiddenCommands = []string{"venv", "venv hook"}
-	c.HelpFunc = cli.BasicHelpFunc("trellis")
+	c.HelpFunc = deprecatedCommandHelpFunc(deprecatedCommands, cli.BasicHelpFunc("trellis"))
 
 	if trellis.CliConfig.LoadPlugins {
 		pluginPaths := filepath.SplitList(os.Getenv("PATH"))

--- a/pkg/server/digitalocean/dns.go
+++ b/pkg/server/digitalocean/dns.go
@@ -1,0 +1,90 @@
+package digitalocean
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	"github.com/digitalocean/godo"
+	"github.com/roots/trellis-cli/pkg/server/types"
+)
+
+const defaultTTL = 300
+
+func (p *Provider) CreateZone(ctx context.Context, domain string) error {
+	req := &godo.DomainCreateRequest{Name: domain}
+	_, _, err := p.client.Domains.Create(ctx, req)
+	return err
+}
+
+func (p *Provider) GetZone(ctx context.Context, domain string) (*types.Zone, bool, error) {
+	d, resp, err := p.client.Domains.Get(ctx, domain)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+
+	return &types.Zone{
+		Name: d.Name,
+		TTL:  d.TTL,
+	}, true, nil
+}
+
+func (p *Provider) CreateRecord(ctx context.Context, domain string, record types.DNSRecord) (*types.DNSRecord, error) {
+	ttl := record.TTL
+	if ttl == 0 {
+		ttl = defaultTTL
+	}
+
+	req := &godo.DomainRecordEditRequest{
+		Type: record.Type,
+		Name: record.Name,
+		Data: record.Value,
+		TTL:  ttl,
+	}
+
+	r, _, err := p.client.Domains.CreateRecord(ctx, domain, req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.DNSRecord{
+		ID:    strconv.Itoa(r.ID),
+		Type:  r.Type,
+		Name:  r.Name,
+		Value: r.Data,
+		TTL:   r.TTL,
+	}, nil
+}
+
+func (p *Provider) DeleteRecord(ctx context.Context, domain string, recordID string) error {
+	id, err := strconv.Atoi(recordID)
+	if err != nil {
+		return err
+	}
+
+	_, err = p.client.Domains.DeleteRecord(ctx, domain, id)
+	return err
+}
+
+func (p *Provider) ListRecords(ctx context.Context, domain string) ([]types.DNSRecord, error) {
+	records, _, err := p.client.Domains.Records(ctx, domain, &godo.ListOptions{Page: 1, PerPage: 100})
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]types.DNSRecord, len(records))
+	for i, r := range records {
+		result[i] = types.DNSRecord{
+			ID:    strconv.Itoa(r.ID),
+			Type:  r.Type,
+			Name:  r.Name,
+			Value: r.Data,
+			TTL:   r.TTL,
+		}
+	}
+
+	return result, nil
+}

--- a/pkg/server/digitalocean/provider.go
+++ b/pkg/server/digitalocean/provider.go
@@ -1,0 +1,278 @@
+package digitalocean
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/digitalocean/godo"
+	"github.com/digitalocean/godo/util"
+	"github.com/roots/trellis-cli/pkg/server/types"
+	"golang.org/x/oauth2"
+)
+
+const baseTag = "trellis"
+
+// Provider implements the types.Provider interface for DigitalOcean.
+type Provider struct {
+	client *godo.Client
+}
+
+// New creates a new DigitalOcean provider with the given API token.
+func New(token string) *Provider {
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	client := godo.NewClient(oauth2.NewClient(context.Background(), ts))
+	return &Provider{client: client}
+}
+
+func (p *Provider) Name() string        { return "digitalocean" }
+func (p *Provider) DisplayName() string { return "DigitalOcean" }
+
+func (p *Provider) CreateServer(ctx context.Context, opts types.CreateServerOptions) (*types.Server, error) {
+	tags := []string{baseTag}
+	for k, v := range opts.Tags {
+		tags = append(tags, fmt.Sprintf("%s:%s", k, v))
+	}
+
+	sshKeys := make([]godo.DropletCreateSSHKey, len(opts.SSHKeyIDs))
+	for i, id := range opts.SSHKeyIDs {
+		sshKeys[i] = godo.DropletCreateSSHKey{Fingerprint: id}
+	}
+
+	req := &godo.DropletCreateRequest{
+		Name:    opts.Name,
+		Region:  opts.Region,
+		Size:    opts.Size,
+		Image:   godo.DropletCreateImage{Slug: opts.Image},
+		SSHKeys: sshKeys,
+		Tags:    tags,
+	}
+
+	droplet, resp, err := p.client.Droplets.Create(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	srv := p.dropletToServer(droplet)
+
+	if len(resp.Links.Actions) > 0 {
+		srv.ID = fmt.Sprintf("%d:%s", droplet.ID, resp.Links.Actions[0].HREF)
+	}
+
+	return srv, nil
+}
+
+func (p *Provider) GetServer(ctx context.Context, id string) (*types.Server, error) {
+	intID, err := p.parseID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	droplet, _, err := p.client.Droplets.Get(ctx, intID)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.dropletToServer(droplet), nil
+}
+
+func (p *Provider) GetServers(ctx context.Context) ([]types.Server, error) {
+	droplets, _, err := p.client.Droplets.List(ctx, &godo.ListOptions{Page: 1, PerPage: 100})
+	if err != nil {
+		return nil, err
+	}
+
+	servers := make([]types.Server, len(droplets))
+	for i, d := range droplets {
+		servers[i] = *p.dropletToServer(&d)
+	}
+
+	return servers, nil
+}
+
+func (p *Provider) WaitForServer(ctx context.Context, id string, timeout time.Duration) (*types.Server, error) {
+	parts := strings.SplitN(id, ":", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid server ID format for waiting: %s", id)
+	}
+
+	dropletID, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return nil, err
+	}
+	monitorURI := parts[1]
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	err = util.WaitForActive(ctx, p.client, monitorURI)
+	if err != nil {
+		return nil, err
+	}
+
+	droplet, _, err := p.client.Droplets.Get(ctx, dropletID)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.dropletToServer(droplet), nil
+}
+
+func (p *Provider) GetRegions(ctx context.Context) ([]types.Region, error) {
+	regions, _, err := p.client.Regions.List(ctx, &godo.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]types.Region, 0, len(regions))
+	for _, r := range regions {
+		if r.Available {
+			result = append(result, types.Region{
+				Slug:      r.Slug,
+				Name:      r.Name,
+				Available: r.Available,
+			})
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Name < result[j].Name
+	})
+
+	return result, nil
+}
+
+func (p *Provider) GetSizes(ctx context.Context, region string) ([]types.Size, error) {
+	sizes, _, err := p.client.Sizes.List(ctx, &godo.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]types.Size, 0)
+	for _, s := range sizes {
+		if !s.Available {
+			continue
+		}
+
+		if !strings.HasPrefix(s.Slug, "s-") && !strings.HasPrefix(s.Slug, "c-") {
+			continue
+		}
+
+		if region != "" && !sizeInRegion(s.Regions, region) {
+			continue
+		}
+
+		result = append(result, types.Size{
+			Slug:         s.Slug,
+			VCPUs:        s.Vcpus,
+			Memory:       s.Memory,
+			Disk:         s.Disk,
+			Transfer:     s.Transfer,
+			PriceMonthly: s.PriceMonthly,
+			PriceHourly:  s.PriceHourly,
+			Available:    s.Available,
+		})
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].PriceMonthly < result[j].PriceMonthly
+	})
+
+	return result, nil
+}
+
+func sizeInRegion(regions []string, region string) bool {
+	for _, r := range regions {
+		if r == region {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Provider) GetSSHKey(ctx context.Context, fingerprint string) (*types.SSHKey, error) {
+	key, resp, err := p.client.Keys.GetByFingerprint(ctx, fingerprint)
+	if err != nil {
+		if resp != nil && resp.StatusCode == 404 {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return &types.SSHKey{
+		ID:          strconv.Itoa(key.ID),
+		Name:        key.Name,
+		Fingerprint: key.Fingerprint,
+		PublicKey:   key.PublicKey,
+	}, nil
+}
+
+func (p *Provider) CreateSSHKey(ctx context.Context, name string, publicKey string) (*types.SSHKey, error) {
+	req := &godo.KeyCreateRequest{
+		Name:      name,
+		PublicKey: publicKey,
+	}
+
+	key, _, err := p.client.Keys.Create(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("could not create SSH key on DigitalOcean: %v", err)
+	}
+
+	return &types.SSHKey{
+		ID:          strconv.Itoa(key.ID),
+		Name:        key.Name,
+		Fingerprint: key.Fingerprint,
+		PublicKey:   key.PublicKey,
+	}, nil
+}
+
+func (p *Provider) dropletToServer(d *godo.Droplet) *types.Server {
+	ip, _ := d.PublicIPv4()
+	ipv6, _ := d.PublicIPv6()
+
+	var region, size string
+	if d.Region != nil {
+		region = d.Region.Slug
+	}
+	if d.Size != nil {
+		size = d.Size.Slug
+	}
+
+	var createdAt time.Time
+	if d.Created != "" {
+		createdAt, _ = time.Parse(time.RFC3339, d.Created)
+	}
+
+	return &types.Server{
+		ID:           strconv.Itoa(d.ID),
+		Name:         d.Name,
+		Status:       mapStatus(d.Status),
+		PublicIPv4:   ip,
+		PublicIPv6:   ipv6,
+		Region:       region,
+		Size:         size,
+		CreatedAt:    createdAt,
+		DashboardURL: fmt.Sprintf("https://cloud.digitalocean.com/droplets/%d", d.ID),
+	}
+}
+
+func (p *Provider) parseID(id string) (int, error) {
+	parts := strings.SplitN(id, ":", 2)
+	return strconv.Atoi(parts[0])
+}
+
+func mapStatus(s string) types.ServerStatus {
+	switch s {
+	case "new":
+		return types.ServerStatusPending
+	case "active":
+		return types.ServerStatusRunning
+	case "off":
+		return types.ServerStatusStopped
+	default:
+		return types.ServerStatusUnknown
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1,0 +1,163 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/cli"
+	"github.com/mitchellh/go-homedir"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/roots/trellis-cli/pkg/server/digitalocean"
+	"github.com/roots/trellis-cli/pkg/server/types"
+)
+
+// Re-export types for convenience
+type (
+	ProviderName        = types.ProviderName
+	Provider            = types.Provider
+	DNSProvider         = types.DNSProvider
+	ProviderWithDNS     = types.ProviderWithDNS
+	Server              = types.Server
+	ServerStatus        = types.ServerStatus
+	CreateServerOptions = types.CreateServerOptions
+	Region              = types.Region
+	Size                = types.Size
+	SSHKey              = types.SSHKey
+	Zone                = types.Zone
+	DNSRecord           = types.DNSRecord
+)
+
+// Re-export constants
+const (
+	ProviderDigitalOcean = types.ProviderDigitalOcean
+	ServerStatusPending  = types.ServerStatusPending
+	ServerStatusStarting = types.ServerStatusStarting
+	ServerStatusRunning  = types.ServerStatusRunning
+	ServerStatusStopped  = types.ServerStatusStopped
+	ServerStatusError    = types.ServerStatusError
+	ServerStatusUnknown  = types.ServerStatusUnknown
+)
+
+// Re-export functions
+var (
+	SupportedProviders = types.SupportedProviders
+	DefaultImage       = types.DefaultImage
+)
+
+// Token environment variable names for each provider.
+var tokenEnvVars = map[ProviderName]string{
+	ProviderDigitalOcean: "DIGITALOCEAN_ACCESS_TOKEN",
+}
+
+// GetProviderToken retrieves the API token for a provider from environment or prompts the user.
+func GetProviderToken(provider ProviderName, ui cli.Ui) (string, error) {
+	envVar := tokenEnvVars[provider]
+	token := os.Getenv(envVar)
+
+	if token == "" {
+		ui.Info(fmt.Sprintf("%s environment variable not set.", envVar))
+		var err error
+		token, err = ui.Ask(fmt.Sprintf("Enter %s API token:", provider))
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return token, nil
+}
+
+// SSHKeyFingerprint returns the MD5 fingerprint of an SSH public key.
+func SSHKeyFingerprint(publicKey ssh.PublicKey) string {
+	return ssh.FingerprintLegacyMD5(publicKey)
+}
+
+// NewProvider creates a new provider instance based on the provider name.
+func NewProvider(name ProviderName, token string) (Provider, error) {
+	switch name {
+	case ProviderDigitalOcean:
+		return digitalocean.New(token), nil
+	default:
+		return nil, fmt.Errorf("unsupported provider: %s", name)
+	}
+}
+
+// NewProviderWithDNS creates a provider that supports DNS management.
+func NewProviderWithDNS(name ProviderName, token string) (ProviderWithDNS, error) {
+	p, err := NewProvider(name, token)
+	if err != nil {
+		return nil, err
+	}
+
+	pwd, ok := p.(ProviderWithDNS)
+	if !ok {
+		return nil, fmt.Errorf("provider %s does not support DNS management", name)
+	}
+
+	return pwd, nil
+}
+
+// DefaultSSHKeyPaths contains the default locations to look for SSH public keys.
+var DefaultSSHKeyPaths = []string{"~/.ssh/id_ed25519.pub", "~/.ssh/id_rsa.pub"}
+
+// LoadSSHKey attempts to load an SSH public key from the given paths.
+// Returns the path of the loaded key, its contents, and the parsed public key.
+func LoadSSHKey(paths []string) (keyPath string, contents []byte, publicKey ssh.PublicKey, err error) {
+	for _, path := range paths {
+		keyPath = path
+		contents, publicKey, err = loadPublicKey(path)
+		if err == nil {
+			break
+		}
+	}
+
+	if publicKey == nil {
+		return "", nil, nil, fmt.Errorf("no valid SSH public key found. Attempted paths: %s", strings.Join(paths, ", "))
+	}
+
+	return keyPath, contents, publicKey, nil
+}
+
+func loadPublicKey(path string) ([]byte, ssh.PublicKey, error) {
+	path, err := homedir.Expand(path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	key, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	publicKey, _, _, _, err := ssh.ParseAuthorizedKey(key)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return key, publicKey, nil
+}
+
+// WaitForSSH waits for SSH to become available on the given host.
+// It polls port 22 until a connection can be established or the context is cancelled.
+func WaitForSSH(ctx context.Context, host string) error {
+	interval := 10 * time.Second
+	addr := net.JoinHostPort(host, "22")
+
+	for {
+		conn, err := net.DialTimeout("tcp", addr, interval)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(interval):
+		}
+	}
+}

--- a/pkg/server/types/types.go
+++ b/pkg/server/types/types.go
@@ -1,0 +1,141 @@
+package types
+
+import (
+	"context"
+	"time"
+)
+
+// ProviderName identifies a cloud provider.
+type ProviderName string
+
+const (
+	ProviderDigitalOcean ProviderName = "digitalocean"
+)
+
+func SupportedProviders() []ProviderName {
+	return []ProviderName{ProviderDigitalOcean}
+}
+
+// DefaultImage returns the default Ubuntu 24.04 image slug for each provider.
+func DefaultImage(provider ProviderName) string {
+	switch provider {
+	case ProviderDigitalOcean:
+		return "ubuntu-24-04-x64"
+	default:
+		return ""
+	}
+}
+
+// Provider defines the interface for cloud server providers.
+type Provider interface {
+	Name() string
+	DisplayName() string
+
+	CreateServer(ctx context.Context, opts CreateServerOptions) (*Server, error)
+	GetServer(ctx context.Context, id string) (*Server, error)
+	GetServers(ctx context.Context) ([]Server, error)
+	WaitForServer(ctx context.Context, id string, timeout time.Duration) (*Server, error)
+
+	GetRegions(ctx context.Context) ([]Region, error)
+	GetSizes(ctx context.Context, region string) ([]Size, error)
+
+	GetSSHKey(ctx context.Context, fingerprint string) (*SSHKey, error)
+	CreateSSHKey(ctx context.Context, name string, publicKey string) (*SSHKey, error)
+}
+
+// DNSProvider is optionally implemented by providers supporting DNS management.
+type DNSProvider interface {
+	CreateZone(ctx context.Context, domain string) error
+	GetZone(ctx context.Context, domain string) (*Zone, bool, error)
+	CreateRecord(ctx context.Context, domain string, record DNSRecord) (*DNSRecord, error)
+	DeleteRecord(ctx context.Context, domain string, recordID string) error
+	ListRecords(ctx context.Context, domain string) ([]DNSRecord, error)
+}
+
+// ProviderWithDNS combines both interfaces.
+type ProviderWithDNS interface {
+	Provider
+	DNSProvider
+}
+
+// ServerStatus represents the state of a server.
+type ServerStatus string
+
+const (
+	ServerStatusPending  ServerStatus = "pending"
+	ServerStatusStarting ServerStatus = "starting"
+	ServerStatusRunning  ServerStatus = "running"
+	ServerStatusStopped  ServerStatus = "stopped"
+	ServerStatusError    ServerStatus = "error"
+	ServerStatusUnknown  ServerStatus = "unknown"
+)
+
+// Server represents a cloud server instance.
+type Server struct {
+	ID           string
+	Name         string
+	Status       ServerStatus
+	PublicIPv4   string
+	PublicIPv6   string
+	Region       string
+	Size         string
+	Image        string
+	CreatedAt    time.Time
+	DashboardURL string
+}
+
+// CreateServerOptions contains the parameters for creating a new server.
+type CreateServerOptions struct {
+	Name      string
+	Region    string
+	Size      string
+	Image     string
+	SSHKeyIDs []string
+	Tags      map[string]string
+}
+
+// Region represents a cloud provider region/location.
+type Region struct {
+	Slug      string
+	Name      string
+	Country   string
+	Available bool
+}
+
+// Size represents a server size/type.
+type Size struct {
+	Slug         string
+	Name         string
+	Description  string
+	VCPUs        int
+	Memory       int // MB
+	Disk         int // GB
+	Transfer     float64
+	PriceHourly  float64
+	PriceMonthly float64
+	Available    bool
+}
+
+// SSHKey represents an SSH public key registered with a provider.
+type SSHKey struct {
+	ID          string
+	Name        string
+	Fingerprint string
+	PublicKey   string
+}
+
+// Zone represents a DNS zone/domain.
+type Zone struct {
+	ID   string
+	Name string
+	TTL  int
+}
+
+// DNSRecord represents a DNS record.
+type DNSRecord struct {
+	ID    string
+	Type  string
+	Name  string
+	Value string
+	TTL   int
+}


### PR DESCRIPTION
Introduce a new server provider abstraction layer in pkg/server that enables support for multiple cloud providers instead of the hardcoded Digitalocean support only. This refactor:

- Adds Provider and DNSProvider interfaces for cloud operations
- Implements DigitalOcean provider using the new abstraction
- Adds `trellis server create` command to replace `trellis droplet create`
- Adds `trellis server dns` command to replace `trellis droplet dns`
- Marks existing `droplet` commands as deprecated
- Updates default image to Ubuntu 24.04
- Adds server.provider config option in trellis.cli.yml

The provider can be configured via:
1. --provider flag
2. TRELLIS_SERVER_PROVIDER environment variable
3. server.provider in trellis.cli.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)