### PR TITLE
GoReleaser: Switch to `homebrew_casks` from `brews`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,16 +37,42 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
-brews:
+homebrew_casks:
   - name: trellis-cli
+    homepage: https://roots.io/trellis
+    description: A CLI to manage Trellis projects
+    caveats: |-
+      ## Virtualenv
+
+      trellis-cli uses Virtualenv to manage dependencies such as Ansible which it 
+      automatically activates and uses when running any `trellis` command.
+      But there's still a lot of times you may want to run `ansible-playbook` or `pip`
+      manually in your shell. To make this experience seamless, trellis-cli offers 
+      shell integration which automatically activates the Virtualenv when you enter a
+      Trellis project, and deactivates when you leave it.
+
+      To enable this integration, add the following to your shell profile:
+
+      Bash (`~/.bash_profile`):
+          eval "$(trellis shell-init bash)"
+
+      Zsh (`~/.zshrc`):
+          eval "$(trellis shell-init zsh)"
+
+      ## Autocompletes
+
+      To install shell completions, run the following:
+        trellis --autocomplete-install
+
+      It should modify your `.bash_profile`, `.zshrc` or similar.
+    binaries:
+      - trellis
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/trellis"]
+          end
     repository:
       owner: roots
       name: homebrew-tap
-    directory: Formula
-    homepage:  https://roots.io/trellis
-    description: A CLI to manage Trellis projects
-    install: |
-      bin.install "trellis"
-    test: |
-      system "#{bin}/trellis --autocomplete-install"
-      system "#{bin}/trellis -v"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,16 +37,42 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
-brews:
+homebrew_casks:
   - name: trellis-cli
+    homepage: https://roots.io/trellis
+    description: A CLI to manage Trellis projects
+    caveats: |-
+      ## Virtualenv
+
+      trellis-cli uses Virtualenv to manage dependencies such as Ansible which it 
+      automatically activates and uses when running any `trellis` command.
+      But there's still a lot of times you may want to run `ansible-playbook` or `pip`
+      manually in your shell. To make this experience seamless, trellis-cli offers 
+      shell integration which automatically activates the Virtualenv when you enter a
+      Trellis project, and deactivates when you leave it.
+
+      To enable this integration, add the following to your shell profile:
+
+      Bash (`~/.bash_profile`):
+          eval "$(trellis shell-init bash)"
+
+      Zsh (`~/.zshrc`):
+          eval "$(trellis shell-init zsh)"
+
+      ## Autocompletes
+
+      To install shell completions, run the following:
+          trellis --autocomplete-install
+
+      It should modify your `.bash_profile`, `.zshrc` or similar.
+    binaries:
+      - trellis
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/trellis"]
+          end
     repository:
       owner: roots
       name: homebrew-tap
-    directory: Formula
-    homepage:  https://roots.io/trellis
-    description: A CLI to manage Trellis projects
-    install: |
-      bin.install "trellis"
-    test: |
-      system "#{bin}/trellis --autocomplete-install"
-      system "#{bin}/trellis -v"

--- a/README.md
+++ b/README.md
@@ -118,21 +118,7 @@ roots/trellis-cli  https://slsa.dev/provenance/v1  .github/workflows/release.yml
 
 ### Autocompletes
 
-Homebrew installs trellis-cli's shell completion automatically by default. If shell completions aren't working, or you installed manually not using Homebrew, you'll need to install the completions manually.
-
-To use the trellis-cli's autocomplete via Homebrew's shell completion:
-
-1. Follow Homebrew's install instructions https://docs.brew.sh/Shell-Completion
-
-    Note: For zsh, as the instructions mention, be sure compinit is autoloaded and called, either explicitly or via a framework like oh-my-zsh.
-
-2. Then run:
-
-    ```bash
-    brew reinstall trellis-cli
-    ```
-
-To install shell completions manually, run the following:
+To install shell completions, run the following:
 
 ```bash
 trellis --autocomplete-install
@@ -309,4 +295,3 @@ Keep track of development and community news.
 - Follow [@rootswp on Twitter](https://twitter.com/rootswp)
 - Follow the [Roots Blog](https://roots.io/blog/)
 - Subscribe to the [Roots Newsletter](https://roots.io/subscribe/)
-

--- a/README.md
+++ b/README.md
@@ -112,21 +112,7 @@ The following 1 attestation matched the policy criteria
 
 ### Autocompletes
 
-Homebrew installs trellis-cli's shell completion automatically by default. If shell completions aren't working, or you installed manually not using Homebrew, you'll need to install the completions manually.
-
-To use the trellis-cli's autocomplete via Homebrew's shell completion:
-
-1. Follow Homebrew's install instructions https://docs.brew.sh/Shell-Completion
-
-    Note: For zsh, as the instructions mention, be sure compinit is autoloaded and called, either explicitly or via a framework like oh-my-zsh.
-
-2. Then run:
-
-    ```bash
-    brew reinstall trellis-cli
-    ```
-
-To install shell completions manually, run the following:
+To install shell completions, run the following:
 
 ```bash
 trellis --autocomplete-install


### PR DESCRIPTION
GoReleaser has deprecated [`brews`](https://goreleaser.com/customization/publish/homebrew_formulas/) since v2.10 (June 8, 2025).

See: https://goreleaser.com/blog/goreleaser-v2.10/

Close #669 

---

Homebrew shell completion installation is currently (v1.18.0) broken. Root cause is unknown.

```console
$ brew install roots/tap/trellis-cli --verbose
==> Fetching downloads for: trellis-cli
==> Verifying checksum for 'b5d7e7afb6032aaaea51bfdbdfb93b7e230b7c13762998d0824abbdb19111b5f--trellis_Darwin_arm64.tar.gz'3.7MB/------
✔︎ Formula trellis-cli (1.18.0)                                                                              Verified     13.7MB/ 13.7MB
==> Installing trellis-cli from roots/tap
mv /private/tmp/homebrew-unpack-20260415-33846-8rr211/LICENSE /private/tmp/trellis-cli-20260415-33846-y79tce/LICENSE
mv /private/tmp/homebrew-unpack-20260415-33846-8rr211/README.md /private/tmp/trellis-cli-20260415-33846-y79tce/README.md
mv /private/tmp/homebrew-unpack-20260415-33846-8rr211/trellis /private/tmp/trellis-cli-20260415-33846-y79tce/trellis
==> Cleaning
==> Finishing up
ln -s ../Cellar/trellis-cli/1.18.0/bin/trellis trellis
==> Summary
🍺  /opt/homebrew/Cellar/trellis-cli/1.18.0: 6 files, 27.5MB, built in 0 seconds
==> Running `brew cleanup trellis-cli`...
Disable this behaviour by setting `HOMEBREW_NO_INSTALL_CLEANUP=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
``` 

https://github.com/roots/homebrew-tap/blob/1f351691393a4c5d1a9979a41a7981b7fe078824/Formula/trellis-cli.rb#L47 is not triggered. My `.zshrc` wasn't modified. Thus, no shell completion is installed.

---

I couldn't add `$ trellis --autocomplete-install` to post-install hook because it cannot be ran twice:

```console
$ trellis --autocomplete-install

# Second run returns error
$ trellis --autocomplete-install
1 error occurred:
        * already installed in /Users/work/.zshrc
```

My failed attempt:

```diff
      hooks:
        post:
          install: |
            if OS.mac?
              system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/trellis"]
            end
+         system_command "#{HOMEBREW_PREFIX}/bin/trellis", args: ["--autocomplete-install"]
+       pre:
+         uninstall: |
+           system_command "#{HOMEBREW_PREFIX}/bin/trellis", args: ["--autocomplete-uninstall"]
```

---

### Migration

When we release the next tag, we have to delete https://github.com/roots/homebrew-tap/blob/master/Formula/trellis-cli.rb

If anyone using brew bundle:

```diff
- brew "roots/tap/trellis-cli"
+ cask "roots/tap/trellis-cli"
```