### PR TITLE
Ubuntu 26.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Current supported settings:
 | Setting | Description | Type | Default |
 | --- | --- | -- | -- |
 | `manager` | VM manager (Options: `auto` (depends on OS), `lima`)| string | "auto" |
-| `ubuntu` | Ubuntu OS version (Options: `22.04`, `24.04`)| string |
+| `ubuntu` | Ubuntu OS version (Options: `22.04`, `24.04`, `26.04`)| string |
 | `hosts_resolver` | VM hosts resolver (Options: `hosts_file`)| string |
 | `instance_name` | Custom name for the VM instance | string | First site name alphabetically |
 | `images` | Custom OS image | object | Set based on `ubuntu` version |

--- a/cli_config/cli_config.go
+++ b/cli_config/cli_config.go
@@ -66,8 +66,8 @@ func (c *Config) LoadFile(path string) error {
 		return fmt.Errorf("%w: unsupported value for `vm.manager`. Must be one of: auto, lima", InvalidConfigErr)
 	}
 
-	if c.Vm.Ubuntu != "" && c.Vm.Ubuntu != "22.04" && c.Vm.Ubuntu != "24.04" {
-		return fmt.Errorf("%w: unsupported value for `vm.ubuntu`. Must be one of: 22.04, 24.04", InvalidConfigErr)
+	if c.Vm.Ubuntu != "" && c.Vm.Ubuntu != "22.04" && c.Vm.Ubuntu != "24.04" && c.Vm.Ubuntu != "26.04" {
+		return fmt.Errorf("%w: unsupported value for `vm.ubuntu`. Must be one of: 22.04, 24.04, 26.04", InvalidConfigErr)
 	}
 
 	if c.Vm.HostsResolver != "" && c.Vm.HostsResolver != "hosts_file" {

--- a/cmd/server_create.go
+++ b/cmd/server_create.go
@@ -41,7 +41,7 @@ func (c *ServerCreateCommand) init() {
 	c.flags.StringVar(&c.providerFlag, "provider", "", "Cloud provider (digitalocean, hetzner)")
 	c.flags.StringVar(&c.sshKey, "ssh-key", "", "Path to SSH public key to automatically add to new server")
 	c.flags.StringVar(&c.region, "region", "", "Region to create the server in")
-	c.flags.StringVar(&c.image, "image", "", "Server image (default: Ubuntu 24.04)")
+	c.flags.StringVar(&c.image, "image", "", "Server image (default: Ubuntu 26.04)")
 	c.flags.StringVar(&c.size, "size", "", "Server size/type to create")
 	c.flags.BoolVar(&c.skipProvision, "skip-provision", false, "Create the server but skip provisioning")
 }
@@ -276,7 +276,7 @@ Arguments:
 Options:
       --provider        Cloud provider (digitalocean, hetzner)
       --region          Region to create the server in
-      --image           Server image (default: Ubuntu 24.04)
+      --image           Server image (default: Ubuntu 26.04)
       --size            Server size/type
       --skip-provision  Skip provision after server is created
       --ssh-key         Path to SSH public key to be added on the server

--- a/pkg/lima/ubuntu.go
+++ b/pkg/lima/ubuntu.go
@@ -25,4 +25,16 @@ var UbuntuImages = map[string][]Image{
 			Arch:     "aarch64",
 		},
 	},
+	"26.04": {
+		{
+			Alias:    "resolute",
+			Location: "https://cloud-images.ubuntu.com/resolute/current/resolute-server-cloudimg-amd64.img",
+			Arch:     "x86_64",
+		},
+		{
+			Alias:    "resolute",
+			Location: "https://cloud-images.ubuntu.com/resolute/current/resolute-server-cloudimg-arm64.img",
+			Arch:     "aarch64",
+		},
+	},
 }

--- a/pkg/server/types/types.go
+++ b/pkg/server/types/types.go
@@ -17,13 +17,13 @@ func SupportedProviders() []ProviderName {
 	return []ProviderName{ProviderDigitalOcean, ProviderHetzner}
 }
 
-// DefaultImage returns the default Ubuntu 24.04 image slug for each provider.
+// DefaultImage returns the default Ubuntu 26.04 image slug for each provider.
 func DefaultImage(provider ProviderName) string {
 	switch provider {
 	case ProviderDigitalOcean:
-		return "ubuntu-24-04-x64"
+		return "ubuntu-26-04-x64"
 	case ProviderHetzner:
-		return "ubuntu-24.04"
+		return "ubuntu-26.04"
 	default:
 		return ""
 	}

--- a/trellis/trellis.go
+++ b/trellis/trellis.go
@@ -39,7 +39,7 @@ var DefaultCliConfig = cli_config.Config{
 	Vm: cli_config.VmConfig{
 		Manager:         "auto",
 		HostsResolver:   "hosts_file",
-		Ubuntu:          "24.04",
+		Ubuntu:          "26.04",
 		InstanceName:    "",
 		ForwardHttpPort: true,
 	},


### PR DESCRIPTION
Prep for Ubuntu 26.04, releasing tomorrow (Apr 22)

[https://canonical.com/blog/ubuntu-26-04-lts-security-update](https://canonical.com/blog/ubuntu-26-04-lts-security-updates)

Need to wait for the GH runner to make Ubuntu 26.04 available, and for DO and Hetzner to support it

Ref https://github.com/roots/trellis/pull/1663
Ref https://github.com/roots/docs/pull/585