### PR TITLE
Remove Windows/WSL support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,6 @@ builds:
   goos:
     - linux
     - darwin
-    - windows
   goarch:
     - 386
     - amd64
@@ -24,9 +23,6 @@ archives:
     {{- if eq .Arch "amd64" }}x86_64
     {{- else if eq .Arch "386" }}i386
     {{- else }}{{ .Arch }}{{ end }}
-  format_overrides:
-    - goos: windows
-      formats: ['zip']
 checksum:
   name_template: '{{ .ProjectName }}_checksums.txt'
 sboms:

--- a/README.md
+++ b/README.md
@@ -68,18 +68,14 @@ trellis-cli provides binary releases for a variety of OSes. These binary version
 3. Find the `trellis` binary in the unpacked directory, and move it to its desired destination (`mv trellis_1.0.0_Darwin_x86_64/trellis /usr/local/bin/trellis`)
 4. Make sure the above path is in your `$PATH`
 
-## Windows Install
-trellis-cli does offer a native Windows exe but we [recommend you use
-WSL](https://roots.io/trellis/docs/installation/#local-development-requirements) for Trellis. The above install methods will work for WSL as well.
+<details>
+<summary>Windows / WSL Install</summary>
 
-If you do want to use the native Windows exe, you'll need to do the following
-setup after downloading the Windows build:
+> **Warning**: trellis-cli does not currently support Windows or WSL.
 
-1. Open system properties
-2. Open environment variables
-3. Under system variables add new variable, `TRELLIS`, pointing to the location of the `trellis.exe` file, like `C:\trellis_1.0.0`
-4. Edit path from system variables and add new named `%TRELLIS%`
-5. Save the changes
+For Windows and WSL support, see the community-maintained fork at [qwatts-dev/trellis-cli](https://github.com/qwatts-dev/trellis-cli).
+
+</details>
 
 ## Verify Attestation
 trellis-cli artifacts can be [cryptographically verified via GitHub CLI](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds#verifying-artifact-attestations-with-the-github-cli).

--- a/app_paths/app_paths.go
+++ b/app_paths/app_paths.go
@@ -3,13 +3,10 @@ package app_paths
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 )
 
 const (
-	appData          = "AppData"
 	trellisConfigDir = "TRELLIS_CONFIG_DIR"
-	localAppData     = "LocalAppData"
 	xdgCacheHome     = "XDG_CACHE_HOME"
 	xdgConfigHome    = "XDG_CONFIG_HOME"
 	xdgDataHome      = "XDG_DATA_HOME"
@@ -18,8 +15,7 @@ const (
 // Config path precedence:
 // 1. TRELLIS_CONFIG_DIR
 // 2. XDG_CONFIG_HOME
-// 3. AppData (windows only)
-// 4. HOME
+// 3. HOME
 func ConfigDir() string {
 	var path string
 
@@ -27,8 +23,6 @@ func ConfigDir() string {
 		path = a
 	} else if b := os.Getenv(xdgConfigHome); b != "" {
 		path = filepath.Join(b, "trellis")
-	} else if c := os.Getenv(appData); runtime.GOOS == "windows" && c != "" {
-		path = filepath.Join(c, "Trellis CLI")
 	} else {
 		d, _ := os.UserHomeDir()
 		path = filepath.Join(d, ".config", "trellis")
@@ -43,14 +37,11 @@ func ConfigPath(path string) string {
 
 // Cache path precedence:
 // 1. XDG_CACHE_HOME
-// 2. LocalAppData (windows only)
-// 3. HOME
+// 2. HOME
 func CacheDir() string {
 	var path string
 	if a := os.Getenv(xdgCacheHome); a != "" {
 		path = filepath.Join(a, "trellis")
-	} else if b := os.Getenv(localAppData); runtime.GOOS == "windows" && b != "" {
-		path = filepath.Join(b, "Trellis CLI")
 	} else {
 		c, _ := os.UserHomeDir()
 		path = filepath.Join(c, ".local", "state", "trellis")
@@ -60,14 +51,11 @@ func CacheDir() string {
 
 // Data path precedence:
 // 1. XDG_DATA_HOME
-// 2. LocalAppData (windows only)
-// 3. HOME
+// 2. HOME
 func DataDir() string {
 	var path string
 	if a := os.Getenv(xdgDataHome); a != "" {
 		path = filepath.Join(a, "trellis")
-	} else if b := os.Getenv(localAppData); runtime.GOOS == "windows" && b != "" {
-		path = filepath.Join(b, "Trellis CLI")
 	} else {
 		c, _ := os.UserHomeDir()
 		path = filepath.Join(c, ".local", "share", "trellis")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -156,7 +156,7 @@ func virtualenvError(ui cli.Ui) {
 	ui.Error("")
 	ui.Error("There are two options:")
 	ui.Error("  1. Ensure Python 3 is installed and the `python3` command works. trellis-cli will use python3's built-in venv feature.")
-	ui.Error("     Ubuntu/Debian users (including Windows WSL): venv is not built-in, to install it run `sudo apt-get install python3-pip python3-venv`")
+	ui.Error("     Ubuntu/Debian users: venv is not built-in, to install it run `sudo apt-get install python3-pip python3-venv`")
 	ui.Error("")
 	ui.Error("  2. Disable trellis-cli's virtualenv feature, and manage dependencies manually, by changing the 'virtualenv_integration' configuration setting to 'false'.")
 }

--- a/cmd/passthrough.go
+++ b/cmd/passthrough.go
@@ -16,9 +16,7 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"syscall"
 )
@@ -31,20 +29,6 @@ type PassthroughCommand struct {
 
 // Taken from https://github.com/kubernetes/kubectl/blob/b155278f1f4a21a0be2d4f6f0037258dee4d1a22/pkg/cmd/cmd.go#L371
 func (c *PassthroughCommand) Run(args []string) int {
-	// Windows does not support exec syscall.
-	if runtime.GOOS == "windows" {
-		cmd := exec.Command(c.Bin, args...)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		cmd.Stdin = os.Stdin
-		cmd.Env = os.Environ()
-		err := cmd.Run()
-		if err == nil {
-			return 0
-		}
-		return 1
-	}
-
 	// invoke cmd binary relaying the environment and args given
 	// append executablePath to cmdArgs, as execve will make first argument the "binary name".
 	if err := syscall.Exec(c.Bin, append([]string{c.Bin}, args...), os.Environ()); err != nil {

--- a/pkg/trust/apply_test.go
+++ b/pkg/trust/apply_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 )
@@ -112,9 +111,6 @@ func TestApplySiteFreshTrust(t *testing.T) {
 }
 
 func TestApplySiteKeyMode0600(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("file modes are POSIX-specific")
-	}
 	in, _, keyPath := applyEnv(t, "/p1", "example.test", true)
 
 	store := &fakeStore{trustResult: TrustResult{Locations: []string{macOSLoginKeychainLocation}}}
@@ -481,9 +477,6 @@ func TestRevokeSiteUntrustErrorPreservesState(t *testing.T) {
 }
 
 func TestWriteFileAtomicSetsMode(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("file modes are POSIX-specific")
-	}
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "secret")
 	if err := writeFileAtomic(path, []byte("hunter2"), 0o600); err != nil {
@@ -508,9 +501,6 @@ func TestWriteFileAtomicSetsMode(t *testing.T) {
 }
 
 func TestWriteFileAtomicReplacesExistingPermissivelyModedFile(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("file modes are POSIX-specific")
-	}
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "secret")
 

--- a/plugin/finder.go
+++ b/plugin/finder.go
@@ -16,7 +16,6 @@ package plugin
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 )
 
@@ -75,16 +74,6 @@ func (o *finder) find() map[string]string {
 func isExecutable(fullPath string) bool {
 	info, err := os.Stat(fullPath)
 	if err != nil {
-		return false
-	}
-
-	if runtime.GOOS == "windows" {
-		fileExt := strings.ToLower(filepath.Ext(fullPath))
-
-		switch fileExt {
-		case ".bat", ".cmd", ".com", ".exe", ".ps1":
-			return true
-		}
 		return false
 	}
 

--- a/scripts/get
+++ b/scripts/get
@@ -52,9 +52,6 @@ execute() {
   (cd "${tmpdir}" && untar "${TARBALL}")
   install -d "${BINDIR}"
   for binexe in "trellis" ; do
-    if [ "$OS" = "windows" ]; then
-      binexe="${binexe}.exe"
-    fi
     install "${srcdir}/${binexe}" "${BINDIR}/"
     log_info "installed ${BINDIR}/${binexe}"
   done
@@ -69,8 +66,6 @@ is_supported_platform() {
     darwin/386) found=0 ;;
     darwin/amd64) found=0 ;;
     darwin/arm64) found=0 ;;
-    windows/386) found=0 ;;
-    windows/amd64) found=0 ;;
   esac
   return $found
 }
@@ -99,10 +94,6 @@ tag_to_version() {
   VERSION=${TAG#v}
 }
 adjust_format() {
-  # change format (tar.gz or zip) based on ARCH
-  case ${ARCH} in
-    windows) FORMAT=zip ;;
-  esac
   true
 }
 adjust_os() {
@@ -112,7 +103,6 @@ adjust_os() {
     amd64) OS=x86_64 ;;
     darwin) OS=Darwin ;;
     linux) OS=Linux ;;
-    windows) OS=Windows ;;
   esac
   true
 }
@@ -123,7 +113,6 @@ adjust_arch() {
     amd64) ARCH=x86_64 ;;
     darwin) ARCH=Darwin ;;
     linux) ARCH=Linux ;;
-    windows) ARCH=Windows ;;
   esac
   true
 }
@@ -187,9 +176,6 @@ log_crit() {
 }
 uname_os() {
   os=$(uname -s | tr '[:upper:]' '[:lower:]')
-  case "$os" in
-    msys_nt) os="windows" ;;
-  esac
   echo "$os"
 }
 uname_arch() {
@@ -219,7 +205,6 @@ uname_os_check() {
     openbsd) return 0 ;;
     plan9) return 0 ;;
     solaris) return 0 ;;
-    windows) return 0 ;;
   esac
   log_crit "uname_os_check '$(uname -s)' got converted to '$os' which is not a GOOS value. Please file bug at https://github.com/client9/shlib"
   return 1


### PR DESCRIPTION
trellis-cli has never functionally supported Windows or WSL, but the codebase still carried Windows-specific code paths and shipped Windows release artifacts. This PR removes all of that and redirects Windows/WSL users to the community-maintained fork at [qwatts-dev/trellis-cli](https://github.com/qwatts-dev/trellis-cli).

🤖 Generated with [Claude Code](https://claude.com/claude-code)