### PR TITLE
Remove goreleaser check from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,6 @@ jobs:
           install-only: true
       - name: Check release (dry-run)
         run: |
-          goreleaser check
           goreleaser release --snapshot --clean --skip publish
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_ACCESS_TOKEN }}


### PR DESCRIPTION
The dry-run of `release` (without publish) will give feedback on this anyway. We don't need to fail on deprecation warnings.